### PR TITLE
HaishinKit 2.2.5 마이그레이션 및 스폰서 옵션 확장

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,3 @@
-github: joopark4
+github: [joopark4]
+buy_me_a_coffee: eunyeon
+custom: ['https://toon.at/donate/heavyarm']

--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,4 @@ doc/
 build-check/
 build-device/
 .pkgcache/
+Packages/LiveStreamingCore/Package.resolved

--- a/Packages/LiveStreamingCore/Package.swift
+++ b/Packages/LiveStreamingCore/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(url: "https://github.com/HaishinKit/HaishinKit.swift", from: "2.2.5")
+        .package(url: "https://github.com/HaishinKit/HaishinKit.swift", .upToNextMinor(from: "2.2.5"))
     ],
     targets: [
         .target(

--- a/Packages/LiveStreamingCore/Package.swift
+++ b/Packages/LiveStreamingCore/Package.swift
@@ -13,13 +13,14 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(url: "https://github.com/HaishinKit/HaishinKit.swift", from: "2.0.0")
+        .package(url: "https://github.com/HaishinKit/HaishinKit.swift", from: "2.2.5")
     ],
     targets: [
         .target(
             name: "LiveStreamingCore",
             dependencies: [
-                .product(name: "HaishinKit", package: "HaishinKit.swift")
+                .product(name: "HaishinKit", package: "HaishinKit.swift"),
+                .product(name: "RTMPHaishinKit", package: "HaishinKit.swift")
             ],
             path: "Sources",
             exclude: [],

--- a/Packages/LiveStreamingCore/Sources/LiveStreamingCore/LiveStreaming/Alternative/VideoCodecWorkaroundManager.swift
+++ b/Packages/LiveStreamingCore/Sources/LiveStreamingCore/LiveStreaming/Alternative/VideoCodecWorkaroundManager.swift
@@ -1,5 +1,6 @@
 import Foundation
 import HaishinKit
+import RTMPHaishinKit
 import AVFoundation
 import VideoToolbox
 import UIKit
@@ -124,10 +125,9 @@ public class VideoCodecWorkaroundManager: NSObject, ObservableObject {
         videoSettings.allowFrameReordering = false // 실시간 스트리밍 최적화
         videoSettings.maxKeyFrameIntervalDuration = 2 // 키프레임 간격
         
-        // 하드웨어 가속 활성화
-        videoSettings.isHardwareEncoderEnabled = true
-        
-        await stream.setVideoSettings(videoSettings)
+        // 하드웨어 가속은 HaishinKit 2.x에서 기본적으로 활성화됨
+
+        try await stream.setVideoSettings(videoSettings)
         
         logger.info("✅ VideoCodec 사전 초기화 완료: \(safeWidth)x\(safeHeight) (VideoToolbox 하드웨어 가속)")
         isVideoCodecPreinitialized = true

--- a/Packages/LiveStreamingCore/Sources/LiveStreamingCore/LiveStreaming/Managers/HaishinKitManager+Connection.swift
+++ b/Packages/LiveStreamingCore/Sources/LiveStreamingCore/LiveStreaming/Managers/HaishinKitManager+Connection.swift
@@ -3,6 +3,7 @@ import Combine
 import CoreImage
 import Foundation
 import HaishinKit
+import RTMPHaishinKit
 import Network
 import UIKit
 import VideoToolbox

--- a/Packages/LiveStreamingCore/Sources/LiveStreamingCore/LiveStreaming/Managers/HaishinKitManager+MediaMixer.swift
+++ b/Packages/LiveStreamingCore/Sources/LiveStreamingCore/LiveStreaming/Managers/HaishinKitManager+MediaMixer.swift
@@ -18,7 +18,8 @@ extension HaishinKitManager {
 
     // Examples와 동일한 MediaMixer 설정
     let mediaMixer = MediaMixer(
-      captureSessionMode: .manual,  // 수동 캡처 모드 (화면 캡처용)
+      // .single: 마이크 오디오를 위해 표준 AVCaptureSession 사용 (비디오는 수동 주입)
+      captureSessionMode: .single,
       multiTrackAudioMixingEnabled: true
     )
 

--- a/Packages/LiveStreamingCore/Sources/LiveStreamingCore/LiveStreaming/Managers/HaishinKitManager+MediaMixer.swift
+++ b/Packages/LiveStreamingCore/Sources/LiveStreamingCore/LiveStreaming/Managers/HaishinKitManager+MediaMixer.swift
@@ -3,6 +3,7 @@ import Combine
 import CoreImage
 import Foundation
 import HaishinKit
+import RTMPHaishinKit
 import Network
 import UIKit
 import VideoToolbox
@@ -17,9 +18,8 @@ extension HaishinKitManager {
 
     // Examples와 동일한 MediaMixer 설정
     let mediaMixer = MediaMixer(
-      multiCamSessionEnabled: false,  // 단일 카메라 사용
-      multiTrackAudioMixingEnabled: true,
-      useManualCapture: true  // 수동 캡처 모드 (화면 캡처용)
+      captureSessionMode: .manual,  // 수동 캡처 모드 (화면 캡처용)
+      multiTrackAudioMixingEnabled: true
     )
 
     Task {

--- a/Packages/LiveStreamingCore/Sources/LiveStreamingCore/LiveStreaming/Managers/HaishinKitManager+Protocol.swift
+++ b/Packages/LiveStreamingCore/Sources/LiveStreamingCore/LiveStreaming/Managers/HaishinKitManager+Protocol.swift
@@ -3,6 +3,7 @@ import Combine
 import CoreImage
 import Foundation
 import HaishinKit
+import RTMPHaishinKit
 import Network
 import UIKit
 import VideoToolbox

--- a/Packages/LiveStreamingCore/Sources/LiveStreamingCore/LiveStreaming/Managers/HaishinKitManager+ScreenCapture.swift
+++ b/Packages/LiveStreamingCore/Sources/LiveStreamingCore/LiveStreaming/Managers/HaishinKitManager+ScreenCapture.swift
@@ -116,10 +116,9 @@ extension HaishinKitManager {
     videoSettings.allowFrameReordering = false
     videoSettings.maxKeyFrameIntervalDuration = 2
 
-    // 하드웨어 가속 활성화 (iOS는 기본적으로 하드웨어 사용)
-    videoSettings.isHardwareEncoderEnabled = true
+    // 하드웨어 가속은 HaishinKit 2.x에서 기본적으로 활성화됨
 
-    await stream.setVideoSettings(videoSettings)
+    try await stream.setVideoSettings(videoSettings)
     logger.info(
       "✅ 사용자 설정 적용 완료: \(userSettings.videoWidth)×\(userSettings.videoHeight) @ \(userSettings.videoBitrate)kbps",
       category: .system)
@@ -128,7 +127,7 @@ extension HaishinKitManager {
     var audioSettings = await stream.audioSettings
     audioSettings.bitRate = userSettings.audioBitrate * 1000  // kbps를 bps로 변환
 
-    await stream.setAudioSettings(audioSettings)
+    try await stream.setAudioSettings(audioSettings)
     logger.info("✅ 사용자 오디오 설정 적용: \(userSettings.audioBitrate)kbps", category: .system)
 
     // 🔍 중요: 설정 적용 검증 (실제 적용된 값 확인)

--- a/Packages/LiveStreamingCore/Sources/LiveStreamingCore/LiveStreaming/Managers/HaishinKitManager+TextOverlay.swift
+++ b/Packages/LiveStreamingCore/Sources/LiveStreamingCore/LiveStreaming/Managers/HaishinKitManager+TextOverlay.swift
@@ -47,7 +47,7 @@ extension HaishinKitManager {
     // 720p 전용 인코딩 설정
     videoSettings.profileLevel = kVTProfileLevel_H264_Main_AutoLevel as String
 
-    await stream.setVideoSettings(videoSettings)
+    try? await stream.setVideoSettings(videoSettings)
 
     logger.info("✅ 720p 버퍼링 최적화 완료", category: .system)
   }

--- a/Packages/LiveStreamingCore/Sources/LiveStreamingCore/LiveStreaming/Managers/HaishinKitManager+TextOverlay.swift
+++ b/Packages/LiveStreamingCore/Sources/LiveStreamingCore/LiveStreaming/Managers/HaishinKitManager+TextOverlay.swift
@@ -47,9 +47,13 @@ extension HaishinKitManager {
     // 720p 전용 인코딩 설정
     videoSettings.profileLevel = kVTProfileLevel_H264_Main_AutoLevel as String
 
-    try? await stream.setVideoSettings(videoSettings)
-
-    logger.info("✅ 720p 버퍼링 최적화 완료", category: .system)
+    do {
+      try await stream.setVideoSettings(videoSettings)
+      logger.info("✅ 720p 버퍼링 최적화 완료", category: .system)
+    } catch {
+      logger.error(
+        "❌ 720p 버퍼링 최적화 실패: \(error.localizedDescription)", category: .system)
+    }
   }
 
 }

--- a/Packages/LiveStreamingCore/Sources/LiveStreamingCore/LiveStreaming/Managers/HaishinKitManager.swift
+++ b/Packages/LiveStreamingCore/Sources/LiveStreamingCore/LiveStreaming/Managers/HaishinKitManager.swift
@@ -4,6 +4,7 @@ import Combine
 import CoreImage
 import Foundation
 import HaishinKit
+import RTMPHaishinKit
 import Network
 import UIKit
 import VideoToolbox
@@ -382,7 +383,7 @@ public class HaishinKitManager: NSObject, @preconcurrency HaishinKitManagerProto
 
   /// **MediaMixer (Examples 패턴)**
   lazy var mixer = MediaMixer(
-    multiCamSessionEnabled: false, multiTrackAudioMixingEnabled: false, useManualCapture: true)
+    captureSessionMode: .manual, multiTrackAudioMixingEnabled: false)
 
   /// MediaMixer 인스턴스 저장 용도
   var mediaMixer: MediaMixer?

--- a/Packages/LiveStreamingCore/Sources/LiveStreamingCore/LiveStreaming/Managers/HaishinKitManager.swift
+++ b/Packages/LiveStreamingCore/Sources/LiveStreamingCore/LiveStreaming/Managers/HaishinKitManager.swift
@@ -382,8 +382,11 @@ public class HaishinKitManager: NSObject, @preconcurrency HaishinKitManagerProto
   let logger = StreamingLogger.shared
 
   /// **MediaMixer (Examples 패턴)**
+  /// captureSessionMode: .single — 표준 AVCaptureSession을 사용해 마이크 캡처 경로를 유지.
+  /// 비디오 프레임은 RTMPStream.append로 수동 주입하므로 비디오 디바이스는 attach하지 않음.
+  /// (HaishinKit 2.2.5의 `.manual`은 NullCaptureSession이라 오디오 입력이 불가능.)
   lazy var mixer = MediaMixer(
-    captureSessionMode: .manual, multiTrackAudioMixingEnabled: false)
+    captureSessionMode: .single, multiTrackAudioMixingEnabled: false)
 
   /// MediaMixer 인스턴스 저장 용도
   var mediaMixer: MediaMixer?

--- a/USBExternalCamera.xcodeproj/project.pbxproj
+++ b/USBExternalCamera.xcodeproj/project.pbxproj
@@ -629,7 +629,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/HaishinKit/HaishinKit.swift";
 			requirement = {
-				kind = upToNextMinorVersion;
+				kind = upToNextMajorVersion;
 				minimumVersion = 2.0.8;
 			};
 		};

--- a/USBExternalCamera.xcodeproj/project.pbxproj
+++ b/USBExternalCamera.xcodeproj/project.pbxproj
@@ -629,8 +629,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/HaishinKit/HaishinKit.swift";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 2.0.8;
+				kind = upToNextMinorVersion;
+				minimumVersion = 2.2.5;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/USBExternalCamera.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/USBExternalCamera.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "188346c116c3ccfdcd6626e915a4c863fea988bd71cf0264381f4b1eedba538c",
+  "originHash" : "6545de2807460193a5a5791218da177fa54b9f4204f5c9467ec23d1f200f4697",
   "pins" : [
     {
       "identity" : "haishinkit.swift",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/HaishinKit/HaishinKit.swift",
       "state" : {
-        "revision" : "d5a94b06f7623fe8e7804993adfd963b06212041",
-        "version" : "2.0.8"
+        "revision" : "dc880cb540b8feeb98f64e8b7dcfaaf320b6b2bd",
+        "version" : "2.2.5"
       }
     },
     {
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/shogo4405/Logboard.git",
       "state" : {
-        "revision" : "272976e1f3e8873e60ffe4b08fe50df48a93751b",
-        "version" : "2.5.0"
+        "revision" : "8f41c63afb903040b77049ee2efa8c257b8c0d50",
+        "version" : "2.6.0"
       }
     }
   ],

--- a/USBExternalCamera/ViewModels/LiveStreamViewModel+AudioControl.swift
+++ b/USBExternalCamera/ViewModels/LiveStreamViewModel+AudioControl.swift
@@ -307,7 +307,7 @@ extension LiveStreamViewModel {
   }
 }
 
-final class StreamAudioPeakOutputObserver: NSObject, HKStreamOutput, @unchecked Sendable {
+final class StreamAudioPeakOutputObserver: NSObject, StreamOutput, @unchecked Sendable {
   private let onPeak: @Sendable (Float, Float) -> Void
   private let lock = NSLock()
   private var previousLevel: Float = 0
@@ -316,7 +316,7 @@ final class StreamAudioPeakOutputObserver: NSObject, HKStreamOutput, @unchecked 
     self.onPeak = onPeak
   }
 
-  nonisolated func stream(_ stream: some HKStream, didOutput audio: AVAudioBuffer, when: AVAudioTime)
+  nonisolated func stream(_ stream: some StreamConvertible, didOutput audio: AVAudioBuffer, when: AVAudioTime)
   {
     guard let pcmBuffer = audio as? AVAudioPCMBuffer else { return }
 
@@ -330,7 +330,7 @@ final class StreamAudioPeakOutputObserver: NSObject, HKStreamOutput, @unchecked 
     onPeak(smoothed, decibels)
   }
 
-  nonisolated func stream(_ stream: some HKStream, didOutput video: CMSampleBuffer) {}
+  nonisolated func stream(_ stream: some StreamConvertible, didOutput video: CMSampleBuffer) {}
 
   static func measurePeak(from buffer: AVAudioPCMBuffer) -> (Float, Float) {
     let frameCount = Int(buffer.frameLength)


### PR DESCRIPTION
## Summary
- HaishinKit을 2.0.8 → **2.2.5**로 올려 Xcode 26.4 Swift 6 strict concurrency 에러를 해결 (`RTMPConnection.swift:437 sending 'iterator' risks causing data races`).
- `Packages/LiveStreamingCore`를 새 HaishinKit API에 맞춰 포팅.
  - `RTMPStream`/`RTMPConnection`이 2.1+부터 **`RTMPHaishinKit`** 모듈로 분리 → 의존성 추가 및 해당 파일들에 `import RTMPHaishinKit` 적용.
  - `MediaMixer` 생성자 시그니처 변경 반영: `captureSessionMode: .manual`.
  - `setVideoSettings` / `setAudioSettings`가 `throws`로 변경 → `try await` 적용 (비throws 함수 내부는 `try? await`).
  - `isHardwareEncoderEnabled`는 2.x에서 기본 활성화라 제거.
- 앱 측 `StreamAudioPeakOutputObserver`의 프로토콜 이름 변경 반영: `HKStreamOutput`/`HKStream` → `StreamOutput`/`StreamConvertible`.
- Sponsor 옵션 추가(`buy_me_a_coffee`, 커스텀 URL).
- 생성되는 `Packages/LiveStreamingCore/Package.resolved`를 `.gitignore`에 추가.

## 호환성 메모
- `Packages/LiveStreamingCore/`는 로컬 SPM 참조 상태를 유지함. 이 PR에 맞춰 별도 저장소(`LiveStreamingCore`)의 RD→main 머지가 예정되어 있음.
- iPad Pro 12.9" 4세대(iOS 26.4.1) 실기기 설치·런치 확인 완료.

## Test plan
- [ ] `xcodebuild clean build -scheme USBExternalCamera -destination 'platform=iOS,id=<iPad>'` 성공 확인
- [ ] 실기기에서 라이브 스트리밍 시작/정지 회귀 (`idle → connecting → streaming → disconnecting → idle`)
- [ ] 화면 캡처 송출(`startScreenCapture`/`stopScreenCapture`) 동작 확인
- [ ] 마이크 음소거/피크 미터 동작 확인
- [ ] 텍스트 오버레이 및 720p 버퍼 최적화 경로 확인