### PR TITLE
feat: 세로/가로 고정 송출 방향 모드 + 프리뷰 전환 안정화

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,3 @@
-github: joopark4
+github: [joopark4]
+buy_me_a_coffee: eunyeon
+custom: ['https://toon.at/donate/heavyarm']

--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,4 @@ doc/
 build-check/
 build-device/
 .pkgcache/
+Packages/LiveStreamingCore/Package.resolved

--- a/Packages/LiveStreamingCore/Package.swift
+++ b/Packages/LiveStreamingCore/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(url: "https://github.com/HaishinKit/HaishinKit.swift", from: "2.2.5")
+        .package(url: "https://github.com/HaishinKit/HaishinKit.swift", .upToNextMinor(from: "2.2.5"))
     ],
     targets: [
         .target(

--- a/Packages/LiveStreamingCore/Package.swift
+++ b/Packages/LiveStreamingCore/Package.swift
@@ -13,13 +13,14 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(url: "https://github.com/HaishinKit/HaishinKit.swift", from: "2.0.0")
+        .package(url: "https://github.com/HaishinKit/HaishinKit.swift", from: "2.2.5")
     ],
     targets: [
         .target(
             name: "LiveStreamingCore",
             dependencies: [
-                .product(name: "HaishinKit", package: "HaishinKit.swift")
+                .product(name: "HaishinKit", package: "HaishinKit.swift"),
+                .product(name: "RTMPHaishinKit", package: "HaishinKit.swift")
             ],
             path: "Sources",
             exclude: [],

--- a/Packages/LiveStreamingCore/Sources/LiveStreamingCore/LiveStreamSettings.swift
+++ b/Packages/LiveStreamingCore/Sources/LiveStreamingCore/LiveStreamSettings.swift
@@ -33,6 +33,9 @@ public final class LiveStreamSettingsModel: @unchecked Sendable {
     
     /// 비디오 높이
     public var videoHeight: Int = 1080
+
+    /// 송출 방향
+    public var streamOrientation: StreamOrientation = StreamOrientation.landscape
     
     /// 프레임 레이트
     public var frameRate: Int = 30
@@ -95,6 +98,7 @@ public final class LiveStreamSettingsModel: @unchecked Sendable {
         videoBitrate: Int = 4500,
         videoWidth: Int = 1920,
         videoHeight: Int = 1080,
+        streamOrientation: StreamOrientation = StreamOrientation.landscape,
         frameRate: Int = 30,
         keyframeInterval: Int = 2,
         videoEncoder: String = "H.264",
@@ -115,6 +119,7 @@ public final class LiveStreamSettingsModel: @unchecked Sendable {
         self.videoBitrate = videoBitrate
         self.videoWidth = videoWidth
         self.videoHeight = videoHeight
+        self.streamOrientation = streamOrientation
         self.frameRate = frameRate
         self.keyframeInterval = keyframeInterval
         self.videoEncoder = videoEncoder
@@ -131,6 +136,10 @@ public final class LiveStreamSettingsModel: @unchecked Sendable {
     /// 비디오 해상도 문자열
     public var resolutionString: String {
         return "\(videoWidth)×\(videoHeight)"
+    }
+
+    public var normalizedResolutionClass: StreamResolutionClass {
+        StreamResolutionDescriptor(width: videoWidth, height: videoHeight).resolutionClass
     }
     
     /// 설정 유효성 검사
@@ -165,6 +174,7 @@ public final class LiveStreamSettingsModel: @unchecked Sendable {
             videoBitrate: videoBitrate,
             videoWidth: videoWidth,
             videoHeight: videoHeight,
+            streamOrientation: streamOrientation,
             frameRate: frameRate,
             keyframeInterval: keyframeInterval,
             videoEncoder: videoEncoder,
@@ -201,6 +211,9 @@ public final class LiveStreamSettingsModel: @unchecked Sendable {
             self.videoBitrate = importData.videoBitrate
             self.videoWidth = importData.videoWidth
             self.videoHeight = importData.videoHeight
+            self.streamOrientation = importData.streamOrientation ?? (
+                importData.videoHeight > importData.videoWidth ? .portrait : .landscape
+            )
             self.frameRate = importData.frameRate
             self.keyframeInterval = importData.keyframeInterval
             self.videoEncoder = importData.videoEncoder
@@ -294,25 +307,30 @@ public final class LiveStreamSettingsModel: @unchecked Sendable {
     
     /// 해상도 프리셋 적용
     public func applyResolutionPreset(_ preset: ResolutionPreset) {
+        let orientation = streamOrientation
         switch preset {
         case .sd480p:
-            videoWidth = 848  // 16의 배수 호환성 개선
-            videoHeight = 480
+            let size = StreamResolutionDescriptor.presetSize(for: .p480, orientation: orientation)
+            videoWidth = size?.width ?? 848
+            videoHeight = size?.height ?? 480
             frameRate = 30
             videoBitrate = 1500
         case .hd720p:
-            videoWidth = 1280
-            videoHeight = 720
+            let size = StreamResolutionDescriptor.presetSize(for: .p720, orientation: orientation)
+            videoWidth = size?.width ?? 1280
+            videoHeight = size?.height ?? 720
             frameRate = 30
             videoBitrate = 2500
         case .fhd1080p:
-            videoWidth = 1920
-            videoHeight = 1080
+            let size = StreamResolutionDescriptor.presetSize(for: .p1080, orientation: orientation)
+            videoWidth = size?.width ?? 1920
+            videoHeight = size?.height ?? 1080
             frameRate = 30
             videoBitrate = 4500
         case .uhd4k:
-            videoWidth = 3840
-            videoHeight = 2160
+            let size = StreamResolutionDescriptor.presetSize(for: .p4k, orientation: orientation)
+            videoWidth = size?.width ?? 3840
+            videoHeight = size?.height ?? 2160
             frameRate = 30
             videoBitrate = 15000
         case .custom:
@@ -368,7 +386,7 @@ public final class LiveStreamSettingsModel: @unchecked Sendable {
     
     /// 유튜브 라이브 스트리밍 표준 프리셋 적용
     public func applyYouTubeLivePreset(_ preset: YouTubeLivePreset) {
-        let settings = preset.settings
+        let settings = preset.settings(for: streamOrientation)
         
         videoWidth = settings.width
         videoHeight = settings.height
@@ -390,12 +408,10 @@ public final class LiveStreamSettingsModel: @unchecked Sendable {
         for preset in YouTubeLivePreset.allCases {
             if preset == .custom { continue }
             
-            let presetSettings = preset.settings
             let bitrateRange = preset.bitrateRange
             
-            if videoWidth == presetSettings.width &&
-               videoHeight == presetSettings.height &&
-               frameRate == presetSettings.frameRate &&
+            if normalizedResolutionClass == preset.resolutionClass &&
+               frameRate == preset.settings(for: streamOrientation).frameRate &&
                videoBitrate >= bitrateRange.min &&
                videoBitrate <= bitrateRange.max {
                 return preset
@@ -463,6 +479,7 @@ private struct ExportData: Codable {
     let videoBitrate: Int
     let videoWidth: Int
     let videoHeight: Int
+    let streamOrientation: StreamOrientation?
     let frameRate: Int
     let keyframeInterval: Int
     let videoEncoder: String

--- a/Packages/LiveStreamingCore/Sources/LiveStreamingCore/LiveStreaming/Alternative/VideoCodecWorkaroundManager.swift
+++ b/Packages/LiveStreamingCore/Sources/LiveStreamingCore/LiveStreaming/Alternative/VideoCodecWorkaroundManager.swift
@@ -1,5 +1,6 @@
 import Foundation
 import HaishinKit
+import RTMPHaishinKit
 import AVFoundation
 import VideoToolbox
 import UIKit
@@ -124,10 +125,9 @@ public class VideoCodecWorkaroundManager: NSObject, ObservableObject {
         videoSettings.allowFrameReordering = false // 실시간 스트리밍 최적화
         videoSettings.maxKeyFrameIntervalDuration = 2 // 키프레임 간격
         
-        // 하드웨어 가속 활성화
-        videoSettings.isHardwareEncoderEnabled = true
-        
-        await stream.setVideoSettings(videoSettings)
+        // 하드웨어 가속은 HaishinKit 2.x에서 기본적으로 활성화됨
+
+        try await stream.setVideoSettings(videoSettings)
         
         logger.info("✅ VideoCodec 사전 초기화 완료: \(safeWidth)x\(safeHeight) (VideoToolbox 하드웨어 가속)")
         isVideoCodecPreinitialized = true

--- a/Packages/LiveStreamingCore/Sources/LiveStreamingCore/LiveStreaming/Managers/HaishinKitManager+Connection.swift
+++ b/Packages/LiveStreamingCore/Sources/LiveStreamingCore/LiveStreaming/Managers/HaishinKitManager+Connection.swift
@@ -3,6 +3,7 @@ import Combine
 import CoreImage
 import Foundation
 import HaishinKit
+import RTMPHaishinKit
 import Network
 import UIKit
 import VideoToolbox

--- a/Packages/LiveStreamingCore/Sources/LiveStreamingCore/LiveStreaming/Managers/HaishinKitManager+MediaMixer.swift
+++ b/Packages/LiveStreamingCore/Sources/LiveStreamingCore/LiveStreaming/Managers/HaishinKitManager+MediaMixer.swift
@@ -18,7 +18,8 @@ extension HaishinKitManager {
 
     // Examples와 동일한 MediaMixer 설정
     let mediaMixer = MediaMixer(
-      captureSessionMode: .manual,  // 수동 캡처 모드 (화면 캡처용)
+      // .single: 마이크 오디오를 위해 표준 AVCaptureSession 사용 (비디오는 수동 주입)
+      captureSessionMode: .single,
       multiTrackAudioMixingEnabled: true
     )
 

--- a/Packages/LiveStreamingCore/Sources/LiveStreamingCore/LiveStreaming/Managers/HaishinKitManager+MediaMixer.swift
+++ b/Packages/LiveStreamingCore/Sources/LiveStreamingCore/LiveStreaming/Managers/HaishinKitManager+MediaMixer.swift
@@ -3,6 +3,7 @@ import Combine
 import CoreImage
 import Foundation
 import HaishinKit
+import RTMPHaishinKit
 import Network
 import UIKit
 import VideoToolbox
@@ -17,9 +18,8 @@ extension HaishinKitManager {
 
     // Examples와 동일한 MediaMixer 설정
     let mediaMixer = MediaMixer(
-      multiCamSessionEnabled: false,  // 단일 카메라 사용
-      multiTrackAudioMixingEnabled: true,
-      useManualCapture: true  // 수동 캡처 모드 (화면 캡처용)
+      captureSessionMode: .manual,  // 수동 캡처 모드 (화면 캡처용)
+      multiTrackAudioMixingEnabled: true
     )
 
     Task {

--- a/Packages/LiveStreamingCore/Sources/LiveStreamingCore/LiveStreaming/Managers/HaishinKitManager+Protocol.swift
+++ b/Packages/LiveStreamingCore/Sources/LiveStreamingCore/LiveStreaming/Managers/HaishinKitManager+Protocol.swift
@@ -127,6 +127,14 @@ extension HaishinKitManager {
       settings.videoHeight = videoHeight
     }
 
+    if let rawOrientation = defaults.string(forKey: "LiveStream.streamOrientation"),
+       let orientation = StreamOrientation(rawValue: rawOrientation)
+    {
+      settings.streamOrientation = orientation
+    } else {
+      settings.streamOrientation = settings.videoHeight > settings.videoWidth ? .portrait : .landscape
+    }
+
     let frameRate = defaults.integer(forKey: "LiveStream.frameRate")
     if frameRate > 0 {
       settings.frameRate = frameRate
@@ -167,6 +175,8 @@ extension HaishinKitManager {
       settings.audioEncoder = audioEncoder
     }
 
+    settings.normalizeVideoDimensionsForOrientation()
+
     logger.info("✅ 스트리밍 설정 로드 완료", category: .system)
     return settings
   }
@@ -175,11 +185,15 @@ extension HaishinKitManager {
   public func saveSettings(_ settings: LiveStreamSettings) {
     logger.info("💾 스트리밍 설정 저장 시작", category: .system)
 
+    var normalizedSettings = settings
+    normalizedSettings.normalizeVideoDimensionsForOrientation()
+
     // 현재 설정과 비교하여 변경된 경우에만 스트리밍 중 실시간 적용
-    let settingsChanged = (currentSettings != nil) && !isSettingsEqual(currentSettings!, settings)
+    let previousSettings = currentSettings
+    let settingsChanged = (previousSettings != nil) && !isSettingsEqual(previousSettings!, normalizedSettings)
     if settingsChanged && isStreaming {
       logger.info("🔄 스트리밍 중 설정 변경 감지 - 실시간 적용 시작", category: .system)
-      currentSettings = settings
+      currentSettings = normalizedSettings
 
       // 비동기로 실시간 설정 적용
       Task {
@@ -191,54 +205,55 @@ extension HaishinKitManager {
       }
     } else {
       // 설정 업데이트 (스트리밍 중이 아니거나 변경사항 없음)
-      currentSettings = settings
+      currentSettings = normalizedSettings
     }
 
     let defaults = UserDefaults.standard
 
     // 기본 스트리밍 설정
-    defaults.set(settings.rtmpURL, forKey: "LiveStream.rtmpURL")
+    defaults.set(normalizedSettings.rtmpURL, forKey: "LiveStream.rtmpURL")
 
     // 스트림 키는 Keychain에 저장 (보안 향상)
-    if !settings.streamKey.isEmpty {
-      if !KeychainManager.shared.saveStreamKey(settings.streamKey) {
+    let shouldPersistStreamKey = !normalizedSettings.streamKey.isEmpty
+      && previousSettings?.streamKey != normalizedSettings.streamKey
+    if shouldPersistStreamKey {
+      if !KeychainManager.shared.saveStreamKey(normalizedSettings.streamKey) {
         logger.error("❌ 스트림 키 Keychain 저장 실패", category: .system)
       }
     }
 
-    defaults.set(settings.streamTitle, forKey: "LiveStream.streamTitle")
+    defaults.set(normalizedSettings.streamTitle, forKey: "LiveStream.streamTitle")
 
     // 비디오 설정
-    defaults.set(settings.videoBitrate, forKey: "LiveStream.videoBitrate")
-    defaults.set(settings.videoWidth, forKey: "LiveStream.videoWidth")
-    defaults.set(settings.videoHeight, forKey: "LiveStream.videoHeight")
-    defaults.set(settings.frameRate, forKey: "LiveStream.frameRate")
+    defaults.set(normalizedSettings.videoBitrate, forKey: "LiveStream.videoBitrate")
+    defaults.set(normalizedSettings.videoWidth, forKey: "LiveStream.videoWidth")
+    defaults.set(normalizedSettings.videoHeight, forKey: "LiveStream.videoHeight")
+    defaults.set(normalizedSettings.streamOrientation.rawValue, forKey: "LiveStream.streamOrientation")
+    defaults.set(normalizedSettings.frameRate, forKey: "LiveStream.frameRate")
 
     // 오디오 설정
-    defaults.set(settings.audioBitrate, forKey: "LiveStream.audioBitrate")
+    defaults.set(normalizedSettings.audioBitrate, forKey: "LiveStream.audioBitrate")
 
     // 고급 설정
-    defaults.set(settings.autoReconnect, forKey: "LiveStream.autoReconnect")
-    defaults.set(settings.isEnabled, forKey: "LiveStream.isEnabled")
-    defaults.set(settings.bufferSize, forKey: "LiveStream.bufferSize")
-    defaults.set(settings.connectionTimeout, forKey: "LiveStream.connectionTimeout")
-    defaults.set(settings.videoEncoder, forKey: "LiveStream.videoEncoder")
-    defaults.set(settings.audioEncoder, forKey: "LiveStream.audioEncoder")
+    defaults.set(normalizedSettings.autoReconnect, forKey: "LiveStream.autoReconnect")
+    defaults.set(normalizedSettings.isEnabled, forKey: "LiveStream.isEnabled")
+    defaults.set(normalizedSettings.bufferSize, forKey: "LiveStream.bufferSize")
+    defaults.set(normalizedSettings.connectionTimeout, forKey: "LiveStream.connectionTimeout")
+    defaults.set(normalizedSettings.videoEncoder, forKey: "LiveStream.videoEncoder")
+    defaults.set(normalizedSettings.audioEncoder, forKey: "LiveStream.audioEncoder")
 
     // 저장 시점 기록
     defaults.set(Date(), forKey: "LiveStream.savedAt")
 
-    // 즉시 디스크에 동기화
-    defaults.synchronize()
-
     logger.info("✅ 스트리밍 설정 저장 완료", category: .system)
     logger.debug("💾 저장된 설정:", category: .system)
     logger.debug("  📍 RTMP URL: [설정됨]", category: .system)
-    logger.debug("  🔑 스트림 키 길이: \(settings.streamKey.count)자", category: .system)
+    logger.debug("  🔑 스트림 키 길이: \(normalizedSettings.streamKey.count)자", category: .system)
     logger.debug(
-      "  📊 비디오: \(settings.videoWidth)×\(settings.videoHeight) @ \(settings.videoBitrate)kbps",
+      "  📊 비디오: \(normalizedSettings.videoWidth)×\(normalizedSettings.videoHeight) @ \(normalizedSettings.videoBitrate)kbps",
       category: .system)
-    logger.debug("  🎵 오디오: \(settings.audioBitrate)kbps", category: .system)
+    logger.debug("  ↕️ 송출 방향: \(normalizedSettings.streamOrientation.rawValue)", category: .system)
+    logger.debug("  🎵 오디오: \(normalizedSettings.audioBitrate)kbps", category: .system)
   }
 
   /// 두 설정이 동일한지 비교 (실시간 적용 여부 결정용)
@@ -248,6 +263,7 @@ extension HaishinKitManager {
   ) -> Bool {
     return settings1.videoWidth == settings2.videoWidth
       && settings1.videoHeight == settings2.videoHeight
+      && settings1.streamOrientation == settings2.streamOrientation
       && settings1.videoBitrate == settings2.videoBitrate
       && settings1.audioBitrate == settings2.audioBitrate
       && settings1.frameRate == settings2.frameRate

--- a/Packages/LiveStreamingCore/Sources/LiveStreamingCore/LiveStreaming/Managers/HaishinKitManager+Protocol.swift
+++ b/Packages/LiveStreamingCore/Sources/LiveStreamingCore/LiveStreaming/Managers/HaishinKitManager+Protocol.swift
@@ -3,6 +3,7 @@ import Combine
 import CoreImage
 import Foundation
 import HaishinKit
+import RTMPHaishinKit
 import Network
 import UIKit
 import VideoToolbox

--- a/Packages/LiveStreamingCore/Sources/LiveStreamingCore/LiveStreaming/Managers/HaishinKitManager+ScreenCapture.swift
+++ b/Packages/LiveStreamingCore/Sources/LiveStreamingCore/LiveStreaming/Managers/HaishinKitManager+ScreenCapture.swift
@@ -116,10 +116,9 @@ extension HaishinKitManager {
     videoSettings.allowFrameReordering = false
     videoSettings.maxKeyFrameIntervalDuration = 2
 
-    // 하드웨어 가속 활성화 (iOS는 기본적으로 하드웨어 사용)
-    videoSettings.isHardwareEncoderEnabled = true
+    // 하드웨어 가속은 HaishinKit 2.x에서 기본적으로 활성화됨
 
-    await stream.setVideoSettings(videoSettings)
+    try await stream.setVideoSettings(videoSettings)
     logger.info(
       "✅ 사용자 설정 적용 완료: \(userSettings.videoWidth)×\(userSettings.videoHeight) @ \(userSettings.videoBitrate)kbps",
       category: .system)
@@ -128,7 +127,7 @@ extension HaishinKitManager {
     var audioSettings = await stream.audioSettings
     audioSettings.bitRate = userSettings.audioBitrate * 1000  // kbps를 bps로 변환
 
-    await stream.setAudioSettings(audioSettings)
+    try await stream.setAudioSettings(audioSettings)
     logger.info("✅ 사용자 오디오 설정 적용: \(userSettings.audioBitrate)kbps", category: .system)
 
     // 🔍 중요: 설정 적용 검증 (실제 적용된 값 확인)

--- a/Packages/LiveStreamingCore/Sources/LiveStreamingCore/LiveStreaming/Managers/HaishinKitManager+ScreenCapture.swift
+++ b/Packages/LiveStreamingCore/Sources/LiveStreamingCore/LiveStreaming/Managers/HaishinKitManager+ScreenCapture.swift
@@ -97,7 +97,7 @@ extension HaishinKitManager {
     }
 
     // 🎯 720p 특화 최적화 적용 (사용자 설정 유지, 내부 최적화만)
-    if settings.videoWidth == 1280 && settings.videoHeight == 720 {
+    if settings.normalizedResolutionClass == .p720 {
       // 사용자 설정은 변경하지 않고, 내부 최적화만 적용
       _ = performanceOptimizer.optimize720pStreaming(settings: userSettings)
       logger.info("🎯 720p 특화 내부 최적화 적용됨 (사용자 설정 유지)", category: .system)
@@ -185,13 +185,13 @@ extension HaishinKitManager {
     var recommendations: [String] = []
 
     // 성능 권장사항만 제공, 강제 변경하지 않음
-    if settings.videoWidth >= 1920 && settings.videoHeight >= 1080 {
+    if settings.normalizedResolutionClass == .p1080 || settings.normalizedResolutionClass == .p4k {
       recommendations.append("⚠️ 1080p는 높은 성능을 요구합니다. 프레임 드롭이 발생할 수 있습니다.")
       recommendations.append("💡 권장: 720p (1280x720)로 설정하면 더 안정적입니다.")
     }
 
     if settings.frameRate > 30 {
-      if settings.videoWidth == 1280 && settings.videoHeight == 720 && settings.frameRate <= 60 {
+      if settings.normalizedResolutionClass == .p720 && settings.frameRate <= 60 {
         recommendations.append("ℹ️ 720p는 60fps까지 지원하지만 CPU/GPU 사용량이 크게 증가합니다.")
         recommendations.append("💡 안정성이 우선이면 30fps를 권장합니다.")
       } else {

--- a/Packages/LiveStreamingCore/Sources/LiveStreamingCore/LiveStreaming/Managers/HaishinKitManager+TextOverlay.swift
+++ b/Packages/LiveStreamingCore/Sources/LiveStreamingCore/LiveStreaming/Managers/HaishinKitManager+TextOverlay.swift
@@ -47,7 +47,7 @@ extension HaishinKitManager {
     // 720p 전용 인코딩 설정
     videoSettings.profileLevel = kVTProfileLevel_H264_Main_AutoLevel as String
 
-    await stream.setVideoSettings(videoSettings)
+    try? await stream.setVideoSettings(videoSettings)
 
     logger.info("✅ 720p 버퍼링 최적화 완료", category: .system)
   }

--- a/Packages/LiveStreamingCore/Sources/LiveStreamingCore/LiveStreaming/Managers/HaishinKitManager+TextOverlay.swift
+++ b/Packages/LiveStreamingCore/Sources/LiveStreamingCore/LiveStreaming/Managers/HaishinKitManager+TextOverlay.swift
@@ -47,9 +47,13 @@ extension HaishinKitManager {
     // 720p 전용 인코딩 설정
     videoSettings.profileLevel = kVTProfileLevel_H264_Main_AutoLevel as String
 
-    try? await stream.setVideoSettings(videoSettings)
-
-    logger.info("✅ 720p 버퍼링 최적화 완료", category: .system)
+    do {
+      try await stream.setVideoSettings(videoSettings)
+      logger.info("✅ 720p 버퍼링 최적화 완료", category: .system)
+    } catch {
+      logger.error(
+        "❌ 720p 버퍼링 최적화 실패: \(error.localizedDescription)", category: .system)
+    }
   }
 
 }

--- a/Packages/LiveStreamingCore/Sources/LiveStreamingCore/LiveStreaming/Managers/HaishinKitManager+TextOverlay.swift
+++ b/Packages/LiveStreamingCore/Sources/LiveStreamingCore/LiveStreaming/Managers/HaishinKitManager+TextOverlay.swift
@@ -31,7 +31,7 @@ extension HaishinKitManager {
   func optimize720pBuffering() async {
     guard let stream = await streamSwitcher.stream,
       let settings = currentSettings,
-      settings.videoWidth == 1280 && settings.videoHeight == 720
+      settings.normalizedResolutionClass == .p720
     else {
       return
     }

--- a/Packages/LiveStreamingCore/Sources/LiveStreamingCore/LiveStreaming/Managers/HaishinKitManager.swift
+++ b/Packages/LiveStreamingCore/Sources/LiveStreamingCore/LiveStreaming/Managers/HaishinKitManager.swift
@@ -4,6 +4,7 @@ import Combine
 import CoreImage
 import Foundation
 import HaishinKit
+import RTMPHaishinKit
 import Network
 import UIKit
 import VideoToolbox
@@ -382,7 +383,7 @@ public class HaishinKitManager: NSObject, @preconcurrency HaishinKitManagerProto
 
   /// **MediaMixer (Examples 패턴)**
   lazy var mixer = MediaMixer(
-    multiCamSessionEnabled: false, multiTrackAudioMixingEnabled: false, useManualCapture: true)
+    captureSessionMode: .manual, multiTrackAudioMixingEnabled: false)
 
   /// MediaMixer 인스턴스 저장 용도
   var mediaMixer: MediaMixer?

--- a/Packages/LiveStreamingCore/Sources/LiveStreamingCore/LiveStreaming/Managers/HaishinKitManager.swift
+++ b/Packages/LiveStreamingCore/Sources/LiveStreamingCore/LiveStreaming/Managers/HaishinKitManager.swift
@@ -382,8 +382,11 @@ public class HaishinKitManager: NSObject, @preconcurrency HaishinKitManagerProto
   let logger = StreamingLogger.shared
 
   /// **MediaMixer (Examples 패턴)**
+  /// captureSessionMode: .single — 표준 AVCaptureSession을 사용해 마이크 캡처 경로를 유지.
+  /// 비디오 프레임은 RTMPStream.append로 수동 주입하므로 비디오 디바이스는 attach하지 않음.
+  /// (HaishinKit 2.2.5의 `.manual`은 NullCaptureSession이라 오디오 입력이 불가능.)
   lazy var mixer = MediaMixer(
-    captureSessionMode: .manual, multiTrackAudioMixingEnabled: false)
+    captureSessionMode: .single, multiTrackAudioMixingEnabled: false)
 
   /// MediaMixer 인스턴스 저장 용도
   var mediaMixer: MediaMixer?

--- a/Packages/LiveStreamingCore/Sources/LiveStreamingCore/LiveStreaming/Managers/PerformanceOptimizationManager+FrameProcessing.swift
+++ b/Packages/LiveStreamingCore/Sources/LiveStreamingCore/LiveStreaming/Managers/PerformanceOptimizationManager+FrameProcessing.swift
@@ -218,7 +218,7 @@ extension PerformanceOptimizationManager {
     /// 720p 스트리밍 특화 최적화 설정 (사용자 설정 유지)
     public func optimize720pStreaming(settings: LiveStreamSettings) -> LiveStreamSettings {
         // 720p 해상도 확인
-        guard settings.videoWidth == 1280 && settings.videoHeight == 720 else {
+        guard settings.normalizedResolutionClass == .p720 else {
             return settings // 720p가 아니면 기본 설정 유지
         }
         

--- a/Packages/LiveStreamingCore/Sources/LiveStreamingCore/LiveStreaming/Types/StreamingModels.swift
+++ b/Packages/LiveStreamingCore/Sources/LiveStreamingCore/LiveStreaming/Types/StreamingModels.swift
@@ -5,6 +5,7 @@
 //  Created by EUN YEON on 5/25/25.
 //
 
+import CoreGraphics
 import Foundation
 
 // MARK: - YouTube Live Preset Enum
@@ -44,18 +45,32 @@ public enum YouTubeLivePreset: String, CaseIterable, Identifiable {
         case .custom: return "slider.horizontal.3"
         }
     }
+
+    public var resolutionClass: StreamResolutionClass {
+        switch self {
+        case .sd480p: return .p480
+        case .hd720p: return .p720
+        case .fhd1080p: return .p1080
+        case .custom: return .custom
+        }
+    }
     
     /// 유튜브 표준 설정값 반환
     public var settings: (width: Int, height: Int, frameRate: Int, videoBitrate: Int, audioBitrate: Int, keyframeInterval: Int) {
+        settings(for: .landscape)
+    }
+
+    public func settings(for orientation: StreamOrientation) -> (width: Int, height: Int, frameRate: Int, videoBitrate: Int, audioBitrate: Int, keyframeInterval: Int) {
+        let size = StreamResolutionDescriptor.presetSize(for: resolutionClass, orientation: orientation)
         switch self {
         case .sd480p:
-            return (848, 480, 30, 1500, 128, 2) // 16의 배수 호환성 개선
+            return (size?.width ?? 848, size?.height ?? 480, 30, 1500, 128, 2)
         case .hd720p:
-            return (1280, 720, 30, 2500, 128, 2) // 권장 기본값 (LiveStreamSettings 기본값과 일치)
+            return (size?.width ?? 1280, size?.height ?? 720, 30, 2500, 128, 2)
         case .fhd1080p:
-            return (1920, 1080, 30, 4500, 128, 2) // 권장 기본값 (유튜브 표준)
+            return (size?.width ?? 1920, size?.height ?? 1080, 30, 4500, 128, 2)
         case .custom:
-            return (1920, 1080, 30, 4500, 128, 2) // 기본값
+            return (1920, 1080, 30, 4500, 128, 2)
         }
     }
     
@@ -78,6 +93,26 @@ public enum LiveStreamingCoreNamespace {
     
     /// 라이브 스트리밍 설정
     public struct LiveStreamSettings: Codable, Sendable {
+        enum CodingKeys: String, CodingKey {
+            case streamTitle
+            case rtmpURL
+            case streamKey
+            case videoBitrate
+            case audioBitrate
+            case videoWidth
+            case videoHeight
+            case streamOrientation
+            case frameRate
+            case autoReconnect
+            case isEnabled
+            case videoEncoder
+            case audioEncoder
+            case useHardwareAcceleration
+            case h264ProfileLevel
+            case bufferSize
+            case connectionTimeout
+        }
+
         /// 스트림 제목
         public var streamTitle: String
         
@@ -98,6 +133,9 @@ public enum LiveStreamingCoreNamespace {
         
         /// 비디오 높이
         public var videoHeight: Int
+
+        /// 송출 방향
+        public var streamOrientation: StreamOrientation
         
         /// 프레임 레이트
         public var frameRate: Int
@@ -135,6 +173,7 @@ public enum LiveStreamingCoreNamespace {
             self.audioBitrate = 128
             self.videoWidth = 1920
             self.videoHeight = 1080
+            self.streamOrientation = .landscape
             self.frameRate = 30
             self.autoReconnect = true
             self.isEnabled = true
@@ -144,6 +183,49 @@ public enum LiveStreamingCoreNamespace {
             self.h264ProfileLevel = "High"
             self.bufferSize = 3
             self.connectionTimeout = 30
+        }
+
+        public init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            self.streamTitle = try container.decodeIfPresent(String.self, forKey: .streamTitle) ?? ""
+            self.rtmpURL = try container.decodeIfPresent(String.self, forKey: .rtmpURL) ?? "rtmp://a.rtmp.youtube.com/live2"
+            self.streamKey = try container.decodeIfPresent(String.self, forKey: .streamKey) ?? ""
+            self.videoBitrate = try container.decodeIfPresent(Int.self, forKey: .videoBitrate) ?? 4500
+            self.audioBitrate = try container.decodeIfPresent(Int.self, forKey: .audioBitrate) ?? 128
+            self.videoWidth = try container.decodeIfPresent(Int.self, forKey: .videoWidth) ?? 1920
+            self.videoHeight = try container.decodeIfPresent(Int.self, forKey: .videoHeight) ?? 1080
+            self.streamOrientation = try container.decodeIfPresent(StreamOrientation.self, forKey: .streamOrientation)
+                ?? (self.videoHeight > self.videoWidth ? .portrait : .landscape)
+            self.frameRate = try container.decodeIfPresent(Int.self, forKey: .frameRate) ?? 30
+            self.autoReconnect = try container.decodeIfPresent(Bool.self, forKey: .autoReconnect) ?? true
+            self.isEnabled = try container.decodeIfPresent(Bool.self, forKey: .isEnabled) ?? true
+            self.videoEncoder = try container.decodeIfPresent(String.self, forKey: .videoEncoder) ?? "H.264"
+            self.audioEncoder = try container.decodeIfPresent(String.self, forKey: .audioEncoder) ?? "AAC"
+            self.useHardwareAcceleration = try container.decodeIfPresent(Bool.self, forKey: .useHardwareAcceleration) ?? true
+            self.h264ProfileLevel = try container.decodeIfPresent(String.self, forKey: .h264ProfileLevel) ?? "High"
+            self.bufferSize = try container.decodeIfPresent(Int.self, forKey: .bufferSize) ?? 3
+            self.connectionTimeout = try container.decodeIfPresent(Int.self, forKey: .connectionTimeout) ?? 30
+        }
+
+        public func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode(streamTitle, forKey: .streamTitle)
+            try container.encode(rtmpURL, forKey: .rtmpURL)
+            try container.encode(streamKey, forKey: .streamKey)
+            try container.encode(videoBitrate, forKey: .videoBitrate)
+            try container.encode(audioBitrate, forKey: .audioBitrate)
+            try container.encode(videoWidth, forKey: .videoWidth)
+            try container.encode(videoHeight, forKey: .videoHeight)
+            try container.encode(streamOrientation, forKey: .streamOrientation)
+            try container.encode(frameRate, forKey: .frameRate)
+            try container.encode(autoReconnect, forKey: .autoReconnect)
+            try container.encode(isEnabled, forKey: .isEnabled)
+            try container.encode(videoEncoder, forKey: .videoEncoder)
+            try container.encode(audioEncoder, forKey: .audioEncoder)
+            try container.encode(useHardwareAcceleration, forKey: .useHardwareAcceleration)
+            try container.encode(h264ProfileLevel, forKey: .h264ProfileLevel)
+            try container.encode(bufferSize, forKey: .bufferSize)
+            try container.encode(connectionTimeout, forKey: .connectionTimeout)
         }
         
         /// YouTube Live 안정성을 위한 추천 설정
@@ -157,16 +239,79 @@ public enum LiveStreamingCoreNamespace {
             settings.autoReconnect = true
             return settings
         }
+
+        public var resolutionDescriptor: StreamResolutionDescriptor {
+            let dimensions = normalizedVideoDimensions
+            return StreamResolutionDescriptor(width: dimensions.width, height: dimensions.height)
+        }
+
+        public var normalizedResolutionClass: StreamResolutionClass {
+            resolutionDescriptor.resolutionClass
+        }
+
+        public var streamLayoutProfile: StreamLayoutProfile {
+            streamOrientation.layoutProfile
+        }
+
+        public var normalizedVideoDimensions: (width: Int, height: Int) {
+            guard videoWidth > 0, videoHeight > 0 else {
+                return (videoWidth, videoHeight)
+            }
+
+            let isPortraitDimensions = videoHeight > videoWidth
+            guard isPortraitDimensions != streamOrientation.isPortrait else {
+                return (videoWidth, videoHeight)
+            }
+
+            return (videoHeight, videoWidth)
+        }
+
+        public var streamAspectRatio: CGFloat {
+            let dimensions = normalizedVideoDimensions
+            guard dimensions.width > 0, dimensions.height > 0 else {
+                return streamLayoutProfile.aspectRatio
+            }
+            return CGFloat(dimensions.width) / CGFloat(dimensions.height)
+        }
+
+        public mutating func normalizeVideoDimensionsForOrientation() {
+            let dimensions = normalizedVideoDimensions
+            videoWidth = dimensions.width
+            videoHeight = dimensions.height
+        }
+
+        public mutating func setStreamOrientation(_ orientation: StreamOrientation) {
+            guard streamOrientation != orientation else { return }
+            streamOrientation = orientation
+            normalizeVideoDimensionsForOrientation()
+        }
+
+        public mutating func applyResolutionClass(_ resolutionClass: StreamResolutionClass) {
+            guard let size = StreamResolutionDescriptor.presetSize(
+                for: resolutionClass,
+                orientation: streamOrientation
+            ) else {
+                return
+            }
+            videoWidth = size.width
+            videoHeight = size.height
+            normalizeVideoDimensionsForOrientation()
+        }
+
+        public func matchesResolutionClass(_ resolutionClass: StreamResolutionClass) -> Bool {
+            normalizedResolutionClass == resolutionClass
+        }
         
         /// 유튜브 라이브 스트리밍 표준 프리셋 적용
         public mutating func applyYouTubeLivePreset(_ preset: YouTubeLivePreset) {
-            let settings = preset.settings
+            let settings = preset.settings(for: streamOrientation)
             
             videoWidth = settings.width
             videoHeight = settings.height
             frameRate = settings.frameRate
             videoBitrate = settings.videoBitrate
             audioBitrate = settings.audioBitrate
+            normalizeVideoDimensionsForOrientation()
             // keyframeInterval은 LiveStreamSettings에 없으므로 생략
             
             // 유튜브 최적화 기본 설정
@@ -182,12 +327,10 @@ public enum LiveStreamingCoreNamespace {
             for preset in YouTubeLivePreset.allCases {
                 if preset == .custom { continue }
                 
-                let presetSettings = preset.settings
                 let bitrateRange = preset.bitrateRange
                 
-                if videoWidth == presetSettings.width &&
-                   videoHeight == presetSettings.height &&
-                   frameRate == presetSettings.frameRate &&
+                if normalizedResolutionClass == preset.resolutionClass &&
+                   frameRate == preset.settings(for: streamOrientation).frameRate &&
                    videoBitrate >= bitrateRange.min &&
                    videoBitrate <= bitrateRange.max {
                     return preset
@@ -198,11 +341,17 @@ public enum LiveStreamingCoreNamespace {
         
         /// 해상도별 추천 비트레이트
         public var recommendedVideoBitrate: Int {
-            switch (videoWidth, videoHeight) {
-            case (1920, 1080): return 4500  // 1080p: 4500-9000 kbps (유튜브 표준)
-            case (1280, 720): return 2500   // 720p: 2500-5000 kbps (유튜브 표준)
-            case (854, 480), (848, 480): return 1500    // 480p: 1000-2000 kbps (유튜브 표준)
-            default: return 2500
+            switch normalizedResolutionClass {
+            case .p1080:
+                return 4500
+            case .p720:
+                return 2500
+            case .p480:
+                return 1500
+            case .p4k:
+                return 15000
+            case .custom:
+                return 2500
             }
         }
         

--- a/Packages/LiveStreamingCore/Sources/LiveStreamingCore/LiveStreaming/Types/StreamingOrientationSupport.swift
+++ b/Packages/LiveStreamingCore/Sources/LiveStreamingCore/LiveStreaming/Types/StreamingOrientationSupport.swift
@@ -1,0 +1,120 @@
+import CoreGraphics
+import Foundation
+
+public enum StreamOrientation: String, Codable, CaseIterable, Sendable {
+  case landscape
+  case portrait
+
+  public var isPortrait: Bool {
+    self == .portrait
+  }
+
+  public var layoutProfile: StreamLayoutProfile {
+    StreamLayoutProfile(orientation: self)
+  }
+
+  public var rotationPolicy: StreamRotationPolicy {
+    isPortrait ? .rotate90Clockwise : .none
+  }
+}
+
+public enum StreamRotationPolicy: Sendable {
+  case none
+  case rotate90Clockwise
+
+  public var degrees: CGFloat {
+    switch self {
+    case .none:
+      return 0
+    case .rotate90Clockwise:
+      return 90
+    }
+  }
+}
+
+public struct StreamLayoutProfile: Sendable {
+  public let orientation: StreamOrientation
+
+  public init(orientation: StreamOrientation) {
+    self.orientation = orientation
+  }
+
+  public var aspectRatio: CGFloat {
+    orientation.isPortrait ? (9.0 / 16.0) : (16.0 / 9.0)
+  }
+
+  public var rotationPolicy: StreamRotationPolicy {
+    orientation.rotationPolicy
+  }
+}
+
+public enum StreamResolutionClass: String, CaseIterable, Sendable {
+  case p480
+  case p720
+  case p1080
+  case p4k
+  case custom
+}
+
+public struct StreamResolutionDescriptor: Sendable, Equatable {
+  public let width: Int
+  public let height: Int
+
+  public init(width: Int, height: Int) {
+    self.width = width
+    self.height = height
+  }
+
+  public var longEdge: Int {
+    max(width, height)
+  }
+
+  public var shortEdge: Int {
+    min(width, height)
+  }
+
+  public var orientation: StreamOrientation {
+    height > width ? .portrait : .landscape
+  }
+
+  public var resolutionClass: StreamResolutionClass {
+    switch (longEdge, shortEdge) {
+    case (848...854, 480), (640, 480):
+      return .p480
+    case (1280, 720):
+      return .p720
+    case (1920, 1080):
+      return .p1080
+    case (3840, 2160):
+      return .p4k
+    default:
+      return .custom
+    }
+  }
+
+  public static func presetSize(
+    for resolutionClass: StreamResolutionClass,
+    orientation: StreamOrientation
+  ) -> (width: Int, height: Int)? {
+    let landscapeSize: (width: Int, height: Int)?
+    switch resolutionClass {
+    case .p480:
+      landscapeSize = (848, 480)
+    case .p720:
+      landscapeSize = (1280, 720)
+    case .p1080:
+      landscapeSize = (1920, 1080)
+    case .p4k:
+      landscapeSize = (3840, 2160)
+    case .custom:
+      landscapeSize = nil
+    }
+
+    guard let landscapeSize else { return nil }
+    if orientation.isPortrait {
+      return (landscapeSize.height, landscapeSize.width)
+    }
+    return landscapeSize
+  }
+}
+

--- a/Packages/LiveStreamingCore/Sources/LiveStreamingCore/LiveStreaming/Utilities/StreamingValidation.swift
+++ b/Packages/LiveStreamingCore/Sources/LiveStreamingCore/LiveStreaming/Utilities/StreamingValidation.swift
@@ -189,7 +189,7 @@ public final class StreamingValidation {
         
         // 일반적인 종횡비 검사 (경고만)
         let aspectRatio = Double(width) / Double(height)
-        let commonRatios = [16.0/9.0, 4.0/3.0, 21.0/9.0] // 16:9, 4:3, 21:9
+        let commonRatios = [16.0/9.0, 9.0/16.0, 4.0/3.0, 3.0/4.0, 21.0/9.0, 9.0/21.0]
         let tolerance = 0.1
         
         let isCommonRatio = commonRatios.contains { abs(aspectRatio - $0) < tolerance }

--- a/Packages/LiveStreamingCore/Tests/LiveStreamingCoreTests/LiveStreamingCoreTests.swift
+++ b/Packages/LiveStreamingCore/Tests/LiveStreamingCoreTests/LiveStreamingCoreTests.swift
@@ -2,7 +2,174 @@ import XCTest
 @testable import LiveStreamingCore
 
 final class LiveStreamingCoreTests: XCTestCase {
-    func testPlaceholder() {
-        XCTAssertTrue(true)
+    func testDefaultSettingsUseLandscapeOrientation() {
+        let settings = LiveStreamSettings()
+
+        XCTAssertEqual(settings.streamOrientation, .landscape)
+        XCTAssertEqual(settings.videoWidth, 1920)
+        XCTAssertEqual(settings.videoHeight, 1080)
+    }
+
+    func testSetStreamOrientationSwapsOnlyDimensions() {
+        var settings = LiveStreamSettings()
+        settings.videoWidth = 1280
+        settings.videoHeight = 720
+        settings.videoBitrate = 2500
+        settings.audioBitrate = 160
+        settings.frameRate = 60
+
+        settings.setStreamOrientation(.portrait)
+
+        XCTAssertEqual(settings.streamOrientation, .portrait)
+        XCTAssertEqual(settings.videoWidth, 720)
+        XCTAssertEqual(settings.videoHeight, 1280)
+        XCTAssertEqual(settings.videoBitrate, 2500)
+        XCTAssertEqual(settings.audioBitrate, 160)
+        XCTAssertEqual(settings.frameRate, 60)
+    }
+
+    func testApplyResolutionClassUsesCurrentOrientation() {
+        var settings = LiveStreamSettings()
+        settings.streamOrientation = .portrait
+
+        settings.applyResolutionClass(.p1080)
+
+        XCTAssertEqual(settings.videoWidth, 1080)
+        XCTAssertEqual(settings.videoHeight, 1920)
+        XCTAssertEqual(settings.normalizedResolutionClass, .p1080)
+    }
+
+    func testYouTubePresetSettingsFollowOrientation() {
+        let landscape = YouTubeLivePreset.hd720p.settings(for: .landscape)
+        let portrait = YouTubeLivePreset.hd720p.settings(for: .portrait)
+
+        XCTAssertEqual(landscape.width, 1280)
+        XCTAssertEqual(landscape.height, 720)
+        XCTAssertEqual(portrait.width, 720)
+        XCTAssertEqual(portrait.height, 1280)
+    }
+
+    func testDetectYouTubePresetNormalizesPortraitResolution() {
+        var settings = LiveStreamSettings()
+        settings.streamOrientation = .portrait
+        settings.videoWidth = 720
+        settings.videoHeight = 1280
+        settings.frameRate = 30
+        settings.videoBitrate = 3000
+
+        XCTAssertEqual(settings.detectYouTubePreset(), .hd720p)
+    }
+
+    func testRecommendedVideoBitrateNormalizesPortraitResolution() {
+        var settings = LiveStreamSettings()
+        settings.streamOrientation = .portrait
+        settings.videoWidth = 720
+        settings.videoHeight = 1280
+
+        XCTAssertEqual(settings.recommendedVideoBitrate, 2500)
+    }
+
+    func testResolutionDescriptorTreatsPortraitAsSameClass() {
+        let landscape = StreamResolutionDescriptor(width: 1280, height: 720)
+        let portrait = StreamResolutionDescriptor(width: 720, height: 1280)
+
+        XCTAssertEqual(landscape.resolutionClass, .p720)
+        XCTAssertEqual(portrait.resolutionClass, .p720)
+    }
+
+    func testLiveStreamSettingsDecodeInfersOrientationWhenMissing() throws {
+        let json = """
+        {
+          "videoWidth": 720,
+          "videoHeight": 1280,
+          "videoBitrate": 2500,
+          "audioBitrate": 128,
+          "frameRate": 30
+        }
+        """
+
+        let settings = try JSONDecoder().decode(LiveStreamSettings.self, from: Data(json.utf8))
+
+        XCTAssertEqual(settings.streamOrientation, .portrait)
+        XCTAssertEqual(settings.normalizedResolutionClass, .p720)
+    }
+
+    func testNormalizedVideoDimensionsFollowStreamOrientation() {
+        var settings = LiveStreamSettings()
+        settings.streamOrientation = .portrait
+        settings.videoWidth = 1920
+        settings.videoHeight = 1080
+
+        XCTAssertEqual(settings.streamAspectRatio, 1080.0 / 1920.0, accuracy: 0.0001)
+
+        settings.normalizeVideoDimensionsForOrientation()
+
+        XCTAssertEqual(settings.videoWidth, 1080)
+        XCTAssertEqual(settings.videoHeight, 1920)
+    }
+
+    func testResolutionDescriptorUsesNormalizedDimensions() {
+        var settings = LiveStreamSettings()
+        settings.streamOrientation = .portrait
+        settings.videoWidth = 1280
+        settings.videoHeight = 720
+
+        XCTAssertEqual(settings.resolutionDescriptor.width, 720)
+        XCTAssertEqual(settings.resolutionDescriptor.height, 1280)
+        XCTAssertEqual(settings.normalizedResolutionClass, .p720)
+    }
+
+    func testLiveStreamSettingsModelExportImportPreservesOrientation() {
+        let source = LiveStreamSettingsModel()
+        source.videoWidth = 1080
+        source.videoHeight = 1920
+        source.streamOrientation = .portrait
+
+        let json = source.exportToJSON()
+
+        let target = LiveStreamSettingsModel()
+        XCTAssertTrue(target.importFromJSON(json))
+        XCTAssertEqual(target.streamOrientation, .portrait)
+        XCTAssertEqual(target.videoWidth, 1080)
+        XCTAssertEqual(target.videoHeight, 1920)
+    }
+
+    func testLiveStreamSettingsModelImportInfersOrientationWhenMissing() {
+        let json = """
+        {
+          "streamTitle": "Test",
+          "rtmpURL": "rtmp://a.rtmp.youtube.com/live2",
+          "streamKey": "stream-key",
+          "videoBitrate": 2500,
+          "videoWidth": 720,
+          "videoHeight": 1280,
+          "frameRate": 30,
+          "keyframeInterval": 2,
+          "videoEncoder": "H.264",
+          "audioBitrate": 128,
+          "audioEncoder": "AAC",
+          "autoReconnect": true,
+          "isEnabled": true,
+          "bufferSize": 3,
+          "connectionTimeout": 30,
+          "exportedAt": "2026-03-19T00:00:00Z"
+        }
+        """
+
+        let model = LiveStreamSettingsModel()
+        XCTAssertTrue(model.importFromJSON(json))
+        XCTAssertEqual(model.streamOrientation, .portrait)
+    }
+    
+    func testApplyYouTubePresetKeepsSelectedOrientation() {
+        var settings = LiveStreamSettings()
+        settings.streamOrientation = .portrait
+
+        settings.applyYouTubeLivePreset(.fhd1080p)
+
+        XCTAssertEqual(settings.videoWidth, 1080)
+        XCTAssertEqual(settings.videoHeight, 1920)
+        XCTAssertEqual(settings.frameRate, 30)
+        XCTAssertEqual(settings.videoBitrate, 4500)
     }
 }

--- a/Resources/en.lproj/Localizable.strings
+++ b/Resources/en.lproj/Localizable.strings
@@ -947,3 +947,7 @@
 "stereo" = "Stereo";
 "stereo_audio" = "Stereo Audio";
 "text_overlay_settings" = "Text Overlay Settings";
+"stream_orientation" = "Stream Orientation";
+"stream_orientation_landscape" = "Landscape";
+"stream_orientation_portrait" = "Portrait";
+"stream_orientation_locked_message" = "Stream orientation can only be changed before the next broadcast.";

--- a/Resources/ko.lproj/Localizable.strings
+++ b/Resources/ko.lproj/Localizable.strings
@@ -940,3 +940,7 @@
 "stereo" = "스테레오";
 "stereo_audio" = "스테레오 오디오";
 "text_overlay_settings" = "텍스트 설정";
+"stream_orientation" = "송출 방향";
+"stream_orientation_landscape" = "가로";
+"stream_orientation_portrait" = "세로";
+"stream_orientation_locked_message" = "방송 중에는 방향을 바꿀 수 없습니다. 다음 방송 전에 변경해주세요.";

--- a/USBExternalCamera.xcodeproj/project.pbxproj
+++ b/USBExternalCamera.xcodeproj/project.pbxproj
@@ -629,7 +629,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/HaishinKit/HaishinKit.swift";
 			requirement = {
-				kind = upToNextMinorVersion;
+				kind = upToNextMajorVersion;
 				minimumVersion = 2.0.8;
 			};
 		};

--- a/USBExternalCamera.xcodeproj/project.pbxproj
+++ b/USBExternalCamera.xcodeproj/project.pbxproj
@@ -629,8 +629,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/HaishinKit/HaishinKit.swift";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 2.0.8;
+				kind = upToNextMinorVersion;
+				minimumVersion = 2.2.5;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/USBExternalCamera.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/USBExternalCamera.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "188346c116c3ccfdcd6626e915a4c863fea988bd71cf0264381f4b1eedba538c",
+  "originHash" : "6545de2807460193a5a5791218da177fa54b9f4204f5c9467ec23d1f200f4697",
   "pins" : [
     {
       "identity" : "haishinkit.swift",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/HaishinKit/HaishinKit.swift",
       "state" : {
-        "revision" : "d5a94b06f7623fe8e7804993adfd963b06212041",
-        "version" : "2.0.8"
+        "revision" : "dc880cb540b8feeb98f64e8b7dcfaaf320b6b2bd",
+        "version" : "2.2.5"
       }
     },
     {
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/shogo4405/Logboard.git",
       "state" : {
-        "revision" : "272976e1f3e8873e60ffe4b08fe50df48a93751b",
-        "version" : "2.5.0"
+        "revision" : "8f41c63afb903040b77049ee2efa8c257b8c0d50",
+        "version" : "2.6.0"
       }
     }
   ],

--- a/USBExternalCamera/ContentView.swift
+++ b/USBExternalCamera/ContentView.swift
@@ -18,6 +18,7 @@ struct ContentView: View {
     @State private var modelContainerError: Bool = false
     @State private var splitViewVisibility: NavigationSplitViewVisibility = .automatic
     @State private var preferredCompactColumn: NavigationSplitViewColumn = .detail
+    @State private var showingLiveStreamSettings = false
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
 
     // MARK: - Initialization
@@ -77,7 +78,8 @@ struct ContentView: View {
         ) {
             SidebarView(
                 viewModel: mainViewModel,
-                onPrimarySelection: showDetailColumnOnCompact
+                onPrimarySelection: showDetailColumnOnCompact,
+                onShowLiveStreamSettings: presentLiveStreamSettings
             )
         } detail: {
             DetailView(
@@ -88,7 +90,7 @@ struct ContentView: View {
         .sheet(isPresented: $mainViewModel.showingPermissionAlert) {
             PermissionSettingsView(viewModel: mainViewModel.permissionViewModel)
         }
-        .sheet(isPresented: $mainViewModel.showingLiveStreamSettings) {
+        .sheet(isPresented: $showingLiveStreamSettings, onDismiss: dismissLiveStreamSettings) {
             LiveStreamSettingsView(viewModel: mainViewModel.liveStreamViewModel)
         }
         .sheet(isPresented: $mainViewModel.showingLoggingSettings) {
@@ -120,6 +122,15 @@ struct ContentView: View {
             splitViewVisibility = .all
             preferredCompactColumn = .sidebar
         }
+    }
+
+    private func presentLiveStreamSettings() {
+        mainViewModel.setLiveStreamSettingsPresented(true)
+        showingLiveStreamSettings = true
+    }
+
+    private func dismissLiveStreamSettings() {
+        mainViewModel.setLiveStreamSettingsPresented(false)
     }
 }
 

--- a/USBExternalCamera/Managers/CameraSessionManager.swift
+++ b/USBExternalCamera/Managers/CameraSessionManager.swift
@@ -156,9 +156,19 @@ public final class CameraSessionManager: NSObject, CameraSessionManaging, @unche
             guard let self, let connection = self.videoOutput.connection(with: .video) else { return }
 
             if #available(iOS 17.0, *) {
-                let angle = rotationAngle ?? 0
-                if connection.isVideoRotationAngleSupported(angle) {
-                    connection.videoRotationAngle = angle
+                if let rotationAngle, connection.isVideoRotationAngleSupported(rotationAngle) {
+                    connection.videoRotationAngle = rotationAngle
+                } else if let orientation, connection.isVideoOrientationSupported {
+                    switch orientation {
+                    case .portrait:
+                        connection.videoOrientation = .portrait
+                    case .portraitUpsideDown:
+                        connection.videoOrientation = .portraitUpsideDown
+                    case .landscapeRight:
+                        connection.videoOrientation = .landscapeRight
+                    case .landscapeLeft:
+                        connection.videoOrientation = .landscapeLeft
+                    }
                 } else if connection.isVideoRotationAngleSupported(0) {
                     connection.videoRotationAngle = 0
                 }
@@ -191,9 +201,9 @@ public final class CameraSessionManager: NSObject, CameraSessionManaging, @unche
             
             // 동일한 설정이면 재적용 생략
             if let current = self.currentStreamingSettings,
-               current.videoWidth == settings.videoWidth &&
-               current.videoHeight == settings.videoHeight &&
+               current.normalizedResolutionClass == settings.normalizedResolutionClass &&
                current.frameRate == settings.frameRate {
+                self.currentStreamingSettings = settings
                 return
             }
             
@@ -220,24 +230,21 @@ public final class CameraSessionManager: NSObject, CameraSessionManaging, @unche
     /// - 지원 해상도: 480p, 720p, 1080p (정확한 해상도 매칭)
     /// - 미지원 해상도는 .high 프리셋으로 폴백
     private func optimizeSessionPreset(for settings: LiveStreamSettings) {
-        let targetResolution = (width: settings.videoWidth, height: settings.videoHeight)
-
-        // 해상도별 프리셋 매핑 (정확한 매칭만 지원)
         let optimalPreset: AVCaptureSession.Preset
-        switch targetResolution {
-        case (854, 480), (848, 480), (640, 480):
+        switch settings.normalizedResolutionClass {
+        case .p480:
             optimalPreset = .vga640x480
             logInfo("📐 480p 스트리밍 → VGA 프리셋 적용", category: .camera)
             
-        case (1280, 720):
+        case .p720:
             optimalPreset = .hd1280x720
             logInfo("📐 720p 스트리밍 → HD 프리셋 적용", category: .camera)
             
-        case (1920, 1080):
+        case .p1080:
             optimalPreset = .hd1920x1080
             logInfo("📐 1080p 스트리밍 → Full HD 프리셋 적용", category: .camera)
             
-        case (3840, 2160):
+        case .p4k:
             if self.captureSession.canSetSessionPreset(.hd4K3840x2160) {
                 optimalPreset = .hd4K3840x2160
                 logInfo("📐 4K 스트리밍 → 4K 프리셋 적용", category: .camera)
@@ -246,7 +253,7 @@ public final class CameraSessionManager: NSObject, CameraSessionManaging, @unche
                 logInfo("📐 4K 스트리밍 (지원안함) → Full HD 프리셋으로 대체", category: .camera)
             }
             
-        default:
+        case .custom:
             optimalPreset = .high
             logInfo("📐 사용자 정의 해상도 → High 프리셋 적용", category: .camera)
         }

--- a/USBExternalCamera/Managers/CameraSessionManager.swift
+++ b/USBExternalCamera/Managers/CameraSessionManager.swift
@@ -83,6 +83,9 @@ public final class CameraSessionManager: NSObject, CameraSessionManaging, @unche
     
     /// 현재 적용된 스트리밍 설정 (중복 설정 방지용 캐시)
     private var currentStreamingSettings: LiveStreamSettings?
+
+    /// 마지막으로 적용한 비디오 출력 연결 설정 (중복 적용 방지용 캐시)
+    private var lastAppliedVideoOutputConfigurationKey: String?
     
     /// 초기화 및 기본 세션 설정
     /// - 세션 프리셋과 비디오 출력을 초기화
@@ -155,6 +158,17 @@ public final class CameraSessionManager: NSObject, CameraSessionManaging, @unche
         sessionQueue.async { [weak self] in
             guard let self, let connection = self.videoOutput.connection(with: .video) else { return }
 
+            let configurationKey = self.makeVideoOutputConfigurationKey(
+                connection: connection,
+                rotationAngle: rotationAngle,
+                orientation: orientation,
+                isMirrored: isMirrored
+            )
+
+            guard self.lastAppliedVideoOutputConfigurationKey != configurationKey else {
+                return
+            }
+
             if #available(iOS 17.0, *) {
                 if let rotationAngle, connection.isVideoRotationAngleSupported(rotationAngle) {
                     connection.videoRotationAngle = rotationAngle
@@ -189,7 +203,40 @@ public final class CameraSessionManager: NSObject, CameraSessionManaging, @unche
                 connection.automaticallyAdjustsVideoMirroring = false
                 connection.isVideoMirrored = isMirrored
             }
+
+            self.lastAppliedVideoOutputConfigurationKey = configurationKey
         }
+    }
+
+    private func makeVideoOutputConfigurationKey(
+        connection: AVCaptureConnection,
+        rotationAngle: CGFloat?,
+        orientation: PreviewVideoOrientation?,
+        isMirrored: Bool
+    ) -> String {
+        let connectionIdentifier = ObjectIdentifier(connection).hashValue
+        let rotationKey = rotationAngle.map { String(Int($0.rounded())) } ?? "nil"
+        let orientationKey: String
+
+        switch orientation {
+        case .portrait:
+            orientationKey = "portrait"
+        case .portraitUpsideDown:
+            orientationKey = "portraitUpsideDown"
+        case .landscapeRight:
+            orientationKey = "landscapeRight"
+        case .landscapeLeft:
+            orientationKey = "landscapeLeft"
+        case .none:
+            orientationKey = "nil"
+        }
+
+        return [
+            "connection:\(connectionIdentifier)",
+            "rotation:\(rotationKey)",
+            "orientation:\(orientationKey)",
+            "mirrored:\(isMirrored)",
+        ].joined(separator: "|")
     }
     
     /// 스트리밍 설정에 맞춰 카메라 하드웨어 품질 최적화

--- a/USBExternalCamera/ViewModels/LiveStreamViewModel+AudioControl.swift
+++ b/USBExternalCamera/ViewModels/LiveStreamViewModel+AudioControl.swift
@@ -307,7 +307,7 @@ extension LiveStreamViewModel {
   }
 }
 
-final class StreamAudioPeakOutputObserver: NSObject, HKStreamOutput, @unchecked Sendable {
+final class StreamAudioPeakOutputObserver: NSObject, StreamOutput, @unchecked Sendable {
   private let onPeak: @Sendable (Float, Float) -> Void
   private let lock = NSLock()
   private var previousLevel: Float = 0
@@ -316,7 +316,7 @@ final class StreamAudioPeakOutputObserver: NSObject, HKStreamOutput, @unchecked 
     self.onPeak = onPeak
   }
 
-  nonisolated func stream(_ stream: some HKStream, didOutput audio: AVAudioBuffer, when: AVAudioTime)
+  nonisolated func stream(_ stream: some StreamConvertible, didOutput audio: AVAudioBuffer, when: AVAudioTime)
   {
     guard let pcmBuffer = audio as? AVAudioPCMBuffer else { return }
 
@@ -330,7 +330,7 @@ final class StreamAudioPeakOutputObserver: NSObject, HKStreamOutput, @unchecked 
     onPeak(smoothed, decibels)
   }
 
-  nonisolated func stream(_ stream: some HKStream, didOutput video: CMSampleBuffer) {}
+  nonisolated func stream(_ stream: some StreamConvertible, didOutput video: CMSampleBuffer) {}
 
   static func measurePeak(from buffer: AVAudioPCMBuffer) -> (Float, Float) {
     let frameCount = Int(buffer.frameLength)

--- a/USBExternalCamera/ViewModels/LiveStreamViewModel+ScreenCapture.swift
+++ b/USBExternalCamera/ViewModels/LiveStreamViewModel+ScreenCapture.swift
@@ -49,7 +49,7 @@ extension LiveStreamViewModel {
     logInfo("✅ [화면캡처] 스트리밍 시작 성공", category: .streaming)
     logInfo(
       "요청 설정값: \(settings.videoWidth)×\(settings.videoHeight) @ \(settings.frameRate)fps, "
-        + "\(settings.videoBitrate)kbps",
+        + "\(settings.videoBitrate)kbps, orientation=\(settings.streamOrientation.rawValue)",
       category: .streaming)
 
     var appliedVideoWidth = settings.videoWidth
@@ -62,7 +62,7 @@ extension LiveStreamViewModel {
       appliedVideoHeight = activeSettings.videoHeight
       logInfo(
         "매니저 반영 설정값: \(activeSettings.videoWidth)×\(activeSettings.videoHeight) @ \(activeSettings.frameRate)fps, "
-          + "\(activeSettings.videoBitrate)kbps",
+          + "\(activeSettings.videoBitrate)kbps, orientation=\(activeSettings.streamOrientation.rawValue)",
         category: .streaming)
       if activeSettings.videoWidth != settings.videoWidth || activeSettings.videoHeight != settings.videoHeight {
         logWarning(

--- a/USBExternalCamera/ViewModels/LiveStreamViewModel+Settings.swift
+++ b/USBExternalCamera/ViewModels/LiveStreamViewModel+Settings.swift
@@ -7,6 +7,20 @@ import SwiftUI
 
 extension LiveStreamViewModel {
   // MARK: - Public Methods - Settings
+  func updateSettings(
+    _ mutation: (inout LiveStreamSettings) -> Void,
+    updateStreamingAvailability shouldUpdateStreamingAvailability: Bool = true
+  ) {
+    var updatedSettings = settings
+    mutation(&updatedSettings)
+    updatedSettings.normalizeVideoDimensionsForOrientation()
+    settings = updatedSettings
+
+    if shouldUpdateStreamingAvailability {
+      updateStreamingAvailability()
+    }
+  }
+
   /// 스트리밍 설정 저장
   func saveSettings() {
     logDebug("💾 [SETTINGS] Saving stream settings...", category: .streaming)
@@ -75,15 +89,19 @@ extension LiveStreamViewModel {
   /// - Parameter preset: 적용할 프리셋
   func applyPreset(_ preset: StreamingPreset) {
     let presetSettings = Self.createPresetSettings(preset)
-    settings.videoWidth = presetSettings.videoWidth
-    settings.videoHeight = presetSettings.videoHeight
-    settings.videoBitrate = presetSettings.videoBitrate
-    settings.audioBitrate = presetSettings.audioBitrate
-    settings.frameRate = presetSettings.frameRate
-    // keyframeInterval, videoEncoder, audioEncoder는 LiveStreamSettings에 없음
+    updateSettings { settings in
+      settings.applyResolutionClass(presetSettings.normalizedResolutionClass)
+      settings.videoBitrate = presetSettings.videoBitrate
+      settings.audioBitrate = presetSettings.audioBitrate
+      settings.frameRate = presetSettings.frameRate
+      // keyframeInterval, videoEncoder, audioEncoder는 LiveStreamSettings에 없음
+    }
+  }
 
-    // 스트리밍 가능 여부 업데이트
-    updateStreamingAvailability()
+  func updateStreamOrientation(_ orientation: StreamOrientation) {
+    updateSettings { settings in
+      settings.setStreamOrientation(orientation)
+    }
   }
 
   /// 설정 초기화 (저장된 설정도 삭제)
@@ -102,17 +120,17 @@ extension LiveStreamViewModel {
   /// 유튜브 라이브 스트리밍 표준 프리셋 적용
   func applyYouTubePreset(_ preset: YouTubeLivePreset) {
     logDebug("🎯 [PRESET] Applying YouTube preset: \(preset.displayName)", category: .streaming)
-    settings.applyYouTubeLivePreset(preset)
-    settings.videoBitrate = YouTubeBitrateAdvisor.recommendedH264Bitrate(
-      width: settings.videoWidth,
-      height: settings.videoHeight,
-      frameRate: settings.frameRate
-    )
-    settings.audioBitrate = Constants.defaultAudioBitrate
+    updateSettings { settings in
+      settings.applyYouTubeLivePreset(preset)
+      settings.videoBitrate = YouTubeBitrateAdvisor.recommendedH264Bitrate(
+        width: settings.videoWidth,
+        height: settings.videoHeight,
+        frameRate: settings.frameRate
+      )
+      settings.audioBitrate = Constants.defaultAudioBitrate
+    }
     // 설정 즉시 저장
     autoSaveSettings()
-    // 스트리밍 가능 여부 업데이트
-    updateStreamingAvailability()
     logDebug("✅ [PRESET] YouTube preset applied successfully", category: .streaming)
     logDebug(
       "📊 [PRESET] Resolution: \(settings.videoWidth)×\(settings.videoHeight)", category: .streaming)
@@ -133,6 +151,7 @@ extension LiveStreamViewModel {
       "LiveStream.videoBitrate",
       "LiveStream.videoWidth",
       "LiveStream.videoHeight",
+      "LiveStream.streamOrientation",
       "LiveStream.frameRate",
       "LiveStream.audioBitrate",
       "LiveStream.autoReconnect",
@@ -148,7 +167,6 @@ extension LiveStreamViewModel {
     }
     // Keychain에서 스트림 키 삭제 (보안 향상)
     KeychainManager.shared.deleteStreamKey()
-    defaults.synchronize()
     logDebug("🗑️ [CLEAR] Saved settings cleared", category: .streaming)
   }
 }

--- a/USBExternalCamera/ViewModels/LiveStreamViewModel+Setup.swift
+++ b/USBExternalCamera/ViewModels/LiveStreamViewModel+Setup.swift
@@ -127,6 +127,7 @@ extension LiveStreamViewModel {
         || defaults.object(forKey: "LiveStream.videoBitrate") != nil
         || defaults.object(forKey: "LiveStream.videoWidth") != nil
         || defaults.object(forKey: "LiveStream.videoHeight") != nil
+        || defaults.object(forKey: "LiveStream.streamOrientation") != nil
         || defaults.object(forKey: "LiveStream.frameRate") != nil
 
       await MainActor.run {

--- a/USBExternalCamera/ViewModels/LiveStreamViewModelSupportTypes.swift
+++ b/USBExternalCamera/ViewModels/LiveStreamViewModelSupportTypes.swift
@@ -3,6 +3,7 @@ import Combine
 import Foundation
 import SwiftData
 import SwiftUI
+import LiveStreamingCore
 
 
 // MARK: - Supporting Types
@@ -46,14 +47,29 @@ enum StreamingPreset: String, CaseIterable {
 enum YouTubeBitrateAdvisor {
   static func recommendedH264Bitrate(width: Int, height: Int, frameRate: Int) -> Int {
     let is60fps = frameRate >= 50
-    if width >= 3840 && height >= 2160 {
+    let resolutionClass = StreamResolutionDescriptor(width: width, height: height).resolutionClass
+
+    switch resolutionClass {
+    case .p4k:
       return is60fps ? 51_000 : 35_000
-    } else if width >= 2560 && height >= 1440 {
-      return is60fps ? 24_000 : 16_000
-    } else if width >= 1920 && height >= 1080 {
+    case .p1080:
       return is60fps ? 9_000 : 4_500
-    } else {
+    case .p720:
       return is60fps ? 6_000 : 2_500
+    case .p480:
+      return is60fps ? 6_000 : 2_500
+    case .custom:
+      let longEdge = max(width, height)
+      let shortEdge = min(width, height)
+      if longEdge >= 3840 && shortEdge >= 2160 {
+        return is60fps ? 51_000 : 35_000
+      } else if longEdge >= 2560 && shortEdge >= 1440 {
+        return is60fps ? 24_000 : 16_000
+      } else if longEdge >= 1920 && shortEdge >= 1080 {
+        return is60fps ? 9_000 : 4_500
+      } else {
+        return is60fps ? 6_000 : 2_500
+      }
     }
   }
 }

--- a/USBExternalCamera/ViewModels/MainViewModel.swift
+++ b/USBExternalCamera/ViewModels/MainViewModel.swift
@@ -11,12 +11,6 @@ import SwiftData
 import Combine
 import LiveStreamingCore
 
-private struct LivePreviewSettingsSnapshot: Equatable {
-    let streamOrientation: StreamOrientation
-    let videoWidth: Int
-    let videoHeight: Int
-}
-
 /// 메인 화면의 ViewModel
 /// MVVM 패턴에서 View와 Model 사이의 중간층 역할을 담당합니다.
 /// UI 상태 관리, 사용자 상호작용 처리, 비즈니스 로직 조율을 담당합니다.
@@ -31,10 +25,6 @@ final class MainViewModel: ObservableObject {
     
     /// 권한 설정 시트 표시 여부
     @Published var showingPermissionAlert = false
-    
-    /// 라이브 스트리밍 설정 시트 표시 상태
-    /// 메인 화면 전체 리렌더를 피하기 위해 발행하지 않고 내부 플래그로만 관리합니다.
-    private(set) var isPresentingLiveStreamSettings = false
     
     /// 로깅 설정 시트 표시 여부 (개발용)
     @Published var showingLoggingSettings = false
@@ -129,12 +119,7 @@ final class MainViewModel: ObservableObject {
     
     /// 라이브 스트리밍 설정 시트 표시 상태 갱신
     func setLiveStreamSettingsPresented(_ isPresented: Bool) {
-        guard isPresentingLiveStreamSettings != isPresented else { return }
-        isPresentingLiveStreamSettings = isPresented
         logDebug("📺 MainViewModel: isPresentingLiveStreamSettings set to \(isPresented)", category: .ui)
-        if !isPresented {
-            objectWillChange.send()
-        }
     }
     
     /// 로깅 설정 화면 표시 (개발용)
@@ -346,38 +331,6 @@ final class MainViewModel: ObservableObject {
             }
             .store(in: &cancellables)
 
-        // 설정 시트를 띄운 상태에서도 프리뷰에 필요한 방향/해상도 변경은 전달합니다.
-        liveStreamViewModel.$settings
-            .map {
-                LivePreviewSettingsSnapshot(
-                    streamOrientation: $0.streamOrientation,
-                    videoWidth: $0.videoWidth,
-                    videoHeight: $0.videoHeight
-                )
-            }
-            .removeDuplicates()
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] snapshot in
-                guard let self else { return }
-                logDebug(
-                    "🖼️ [MainViewModel] 프리뷰 설정 변경 전달: \(snapshot.streamOrientation.rawValue) \(snapshot.videoWidth)x\(snapshot.videoHeight)",
-                    category: .ui
-                )
-                self.objectWillChange.send()
-            }
-            .store(in: &cancellables)
-
-        // LiveStreamViewModel 내부 상태 변경(피크/음소거/진단 등)을
-        // MainViewModel 관찰 체인으로 전달해 UI가 사용자 입력 없이 즉시 갱신되도록 보장
-        liveStreamViewModel.objectWillChange
-            .receive(on: DispatchQueue.main)
-            .throttle(for: .milliseconds(33), scheduler: DispatchQueue.main, latest: true)
-            .sink { [weak self] _ in
-                guard let self else { return }
-                guard !self.isPresentingLiveStreamSettings else { return }
-                self.objectWillChange.send()
-            }
-            .store(in: &cancellables)
     }
     
     /// 현재 상태에 따른 UI 상태 업데이트

--- a/USBExternalCamera/ViewModels/MainViewModel.swift
+++ b/USBExternalCamera/ViewModels/MainViewModel.swift
@@ -11,6 +11,12 @@ import SwiftData
 import Combine
 import LiveStreamingCore
 
+private struct LivePreviewSettingsSnapshot: Equatable {
+    let streamOrientation: StreamOrientation
+    let videoWidth: Int
+    let videoHeight: Int
+}
+
 /// 메인 화면의 ViewModel
 /// MVVM 패턴에서 View와 Model 사이의 중간층 역할을 담당합니다.
 /// UI 상태 관리, 사용자 상호작용 처리, 비즈니스 로직 조율을 담당합니다.
@@ -26,8 +32,9 @@ final class MainViewModel: ObservableObject {
     /// 권한 설정 시트 표시 여부
     @Published var showingPermissionAlert = false
     
-    /// 라이브 스트리밍 설정 시트 표시 여부
-    @Published var showingLiveStreamSettings = false
+    /// 라이브 스트리밍 설정 시트 표시 상태
+    /// 메인 화면 전체 리렌더를 피하기 위해 발행하지 않고 내부 플래그로만 관리합니다.
+    private(set) var isPresentingLiveStreamSettings = false
     
     /// 로깅 설정 시트 표시 여부 (개발용)
     @Published var showingLoggingSettings = false
@@ -120,11 +127,14 @@ final class MainViewModel: ObservableObject {
         logDebug("🔧 MainViewModel: showingPermissionAlert set to \(showingPermissionAlert)", category: .ui)
     }
     
-    /// 라이브 스트리밍 설정 화면 표시
-    func showLiveStreamSettings() {
-        logDebug("📺 MainViewModel: showLiveStreamSettings() called", category: .ui)
-        showingLiveStreamSettings = true
-        logDebug("📺 MainViewModel: showingLiveStreamSettings set to \(showingLiveStreamSettings)", category: .ui)
+    /// 라이브 스트리밍 설정 시트 표시 상태 갱신
+    func setLiveStreamSettingsPresented(_ isPresented: Bool) {
+        guard isPresentingLiveStreamSettings != isPresented else { return }
+        isPresentingLiveStreamSettings = isPresented
+        logDebug("📺 MainViewModel: isPresentingLiveStreamSettings set to \(isPresented)", category: .ui)
+        if !isPresented {
+            objectWillChange.send()
+        }
     }
     
     /// 로깅 설정 화면 표시 (개발용)
@@ -336,13 +346,36 @@ final class MainViewModel: ObservableObject {
             }
             .store(in: &cancellables)
 
+        // 설정 시트를 띄운 상태에서도 프리뷰에 필요한 방향/해상도 변경은 전달합니다.
+        liveStreamViewModel.$settings
+            .map {
+                LivePreviewSettingsSnapshot(
+                    streamOrientation: $0.streamOrientation,
+                    videoWidth: $0.videoWidth,
+                    videoHeight: $0.videoHeight
+                )
+            }
+            .removeDuplicates()
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] snapshot in
+                guard let self else { return }
+                logDebug(
+                    "🖼️ [MainViewModel] 프리뷰 설정 변경 전달: \(snapshot.streamOrientation.rawValue) \(snapshot.videoWidth)x\(snapshot.videoHeight)",
+                    category: .ui
+                )
+                self.objectWillChange.send()
+            }
+            .store(in: &cancellables)
+
         // LiveStreamViewModel 내부 상태 변경(피크/음소거/진단 등)을
         // MainViewModel 관찰 체인으로 전달해 UI가 사용자 입력 없이 즉시 갱신되도록 보장
         liveStreamViewModel.objectWillChange
             .receive(on: DispatchQueue.main)
             .throttle(for: .milliseconds(33), scheduler: DispatchQueue.main, latest: true)
             .sink { [weak self] _ in
-                self?.objectWillChange.send()
+                guard let self else { return }
+                guard !self.isPresentingLiveStreamSettings else { return }
+                self.objectWillChange.send()
             }
             .store(in: &cancellables)
     }

--- a/USBExternalCamera/Views/Camera/CameraPreviewUIView.swift
+++ b/USBExternalCamera/Views/Camera/CameraPreviewUIView.swift
@@ -66,6 +66,22 @@ final class CameraPreviewUIView: UIView {
     }
   }
 
+  /// 프리뷰와 송출 레이아웃 기준이 되는 현재 스트리밍 설정
+  var streamingSettings: LiveStreamSettings? {
+    didSet {
+      guard hasMeaningfulStreamingSettingChange(from: oldValue, to: streamingSettings) else { return }
+      let orientationChanged = oldValue?.streamOrientation != streamingSettings?.streamOrientation
+      DispatchQueue.main.async { [weak self] in
+        guard let self else { return }
+        if orientationChanged {
+          self.requiresPreviewLayerRebuildForOrientationChange = true
+        }
+        self.invalidateVideoOutputConnectionConfigCache()
+        self.refreshPreviewLayerGeometryIfNeeded(force: true)
+      }
+    }
+  }
+
   /// 스트리밍 상태
   private var isStreaming: Bool = false
 
@@ -74,6 +90,17 @@ final class CameraPreviewUIView: UIView {
 
   /// 비디오 출력 연결 설정 캐시 키 (카메라/방향 변화 시에만 재설정)
   private var videoOutputConnectionConfigKey: String?
+
+  /// 프리뷰 레이어 지오메트리 재구성 캐시 키
+  private var previewGeometryConfigKey: String?
+
+  /// 가로/세로 전환 시 AVFoundation 프리뷰 레이어 재생성이 필요한지 여부
+  private var requiresPreviewLayerRebuildForOrientationChange = false
+
+  #if DEBUG
+    /// 마지막으로 기록한 프리뷰 디버그 스냅샷
+    private var lastPreviewDebugSnapshot: String?
+  #endif
 
   /// 카메라 컨트롤 오버레이
   private lazy var controlOverlay: CameraControlOverlay = {
@@ -212,9 +239,236 @@ final class CameraPreviewUIView: UIView {
     addGestureRecognizer(zoomPinchGesture)
   }
 
+  private func hasMeaningfulStreamingSettingChange(
+    from oldValue: LiveStreamSettings?,
+    to newValue: LiveStreamSettings?
+  ) -> Bool {
+    switch (oldValue, newValue) {
+    case (nil, nil):
+      return false
+    case (nil, _), (_, nil):
+      return true
+    case let (oldValue?, newValue?):
+      return oldValue.videoWidth != newValue.videoWidth
+        || oldValue.videoHeight != newValue.videoHeight
+        || oldValue.streamOrientation != newValue.streamOrientation
+    }
+  }
+
+  private var activeStreamingSettings: LiveStreamSettings {
+    streamingSettings ?? haishinKitManager?.getCurrentSettings() ?? LiveStreamSettings()
+  }
+
+  private var activeStreamLayoutProfile: StreamLayoutProfile {
+    activeStreamingSettings.streamLayoutProfile
+  }
+
+  private var previewAspectRatio: CGFloat {
+    let aspectRatio = activeStreamingSettings.streamAspectRatio
+    return aspectRatio > 0 ? aspectRatio : activeStreamLayoutProfile.aspectRatio
+  }
+
+  private var currentInterfaceOrientation: UIInterfaceOrientation? {
+    window?.windowScene?.interfaceOrientation
+  }
+
+  private var previewNeedsVisualQuarterTurn: Bool {
+    false
+  }
+
+  private var previewVisualRotationAngle: CGFloat {
+    0
+  }
+
+  private func calculatePreviewFrame(in viewBounds: CGRect) -> CGRect {
+    let aspectRatio = previewAspectRatio
+    guard viewBounds.width > 0, viewBounds.height > 0, aspectRatio > 0 else {
+      return viewBounds
+    }
+
+    if viewBounds.width / viewBounds.height > aspectRatio {
+      let width = viewBounds.height * aspectRatio
+      let offsetX = (viewBounds.width - width) / 2
+      return CGRect(x: offsetX, y: 0, width: width, height: viewBounds.height)
+    }
+
+    let height = viewBounds.width / aspectRatio
+    let offsetY = (viewBounds.height - height) / 2
+    return CGRect(x: 0, y: offsetY, width: viewBounds.width, height: height)
+  }
+
+  private var previewConnectionOrientation: PreviewVideoOrientation {
+    if let interfaceOrientation = currentInterfaceOrientation {
+      return previewVideoOrientation(for: interfaceOrientation)
+    }
+
+    if let deviceOrientation = fallbackPreviewVideoOrientationFromDevice() {
+      return deviceOrientation
+    }
+
+    return .portrait
+  }
+
+  private var previewConnectionRotationAngle: CGFloat? {
+    return nil
+  }
+
+  private var videoOutputRotationAngle: CGFloat? {
+    previewConnectionRotationAngle
+  }
+
+  private var videoOutputOrientation: PreviewVideoOrientation {
+    previewConnectionOrientation
+  }
+
+  private func previewLayerBounds(for previewFrame: CGRect) -> CGRect {
+    CGRect(origin: .zero, size: previewFrame.size)
+  }
+
+  private func applyPreviewConnectionOrientation(to connection: AVCaptureConnection?) {
+    guard let connection else { return }
+
+    guard connection.isVideoOrientationSupported else { return }
+
+    switch previewConnectionOrientation {
+    case .portrait:
+      connection.videoOrientation = .portrait
+    case .portraitUpsideDown:
+      connection.videoOrientation = .portraitUpsideDown
+    case .landscapeRight:
+      connection.videoOrientation = .landscapeRight
+    case .landscapeLeft:
+      connection.videoOrientation = .landscapeLeft
+    }
+  }
+
+  private func previewVideoOrientation(for interfaceOrientation: UIInterfaceOrientation)
+    -> PreviewVideoOrientation
+  {
+    switch interfaceOrientation {
+    case .portrait:
+      return .portrait
+    case .portraitUpsideDown:
+      return .portraitUpsideDown
+    case .landscapeLeft:
+      return .landscapeLeft
+    case .landscapeRight:
+      return .landscapeRight
+    default:
+      return .portrait
+    }
+  }
+
+  private func fallbackPreviewVideoOrientationFromDevice() -> PreviewVideoOrientation? {
+    switch UIDevice.current.orientation {
+    case .portrait:
+      return .portrait
+    case .portraitUpsideDown:
+      return .portraitUpsideDown
+    case .landscapeLeft:
+      return .landscapeRight
+    case .landscapeRight:
+      return .landscapeLeft
+    default:
+      return nil
+    }
+  }
+
+  private func roundedPreviewDimension(_ value: CGFloat) -> Int {
+    Int(value.rounded(.toNearestOrAwayFromZero))
+  }
+
+  private func makePreviewGeometryConfigKey() -> String {
+    let previewFrame = calculatePreviewFrame(in: bounds)
+    let interfaceOrientation = window?.windowScene?.interfaceOrientation.rawValue ?? -1
+    let sessionIdentifier = captureSession.map { ObjectIdentifier($0).hashValue } ?? 0
+
+    return [
+      "bounds:\(roundedPreviewDimension(bounds.width))x\(roundedPreviewDimension(bounds.height))",
+      "preview:\(roundedPreviewDimension(previewFrame.width))x\(roundedPreviewDimension(previewFrame.height))",
+      "stream:\(activeStreamingSettings.streamOrientation.rawValue)",
+      "session:\(sessionIdentifier)",
+    ].joined(separator: "|")
+  }
+
+  private func invalidatePreviewGeometryConfigCache() {
+    previewGeometryConfigKey = nil
+  }
+
+  private func refreshPreviewLayerGeometryIfNeeded(force: Bool = false) {
+    guard Thread.isMainThread else {
+      DispatchQueue.main.async { [weak self] in
+        self?.refreshPreviewLayerGeometryIfNeeded(force: force)
+      }
+      return
+    }
+
+    guard let session = captureSession else { return }
+
+    let geometryKey = makePreviewGeometryConfigKey()
+    let needsPreviewLayerRebuild =
+      previewLayer == nil
+      || previewLayer?.session !== session
+      || requiresPreviewLayerRebuildForOrientationChange
+
+    guard force || needsPreviewLayerRebuild || previewGeometryConfigKey != geometryKey else {
+      updatePreviewPresentation(forceConnectionRefresh: force)
+      return
+    }
+
+    previewGeometryConfigKey = geometryKey
+    if needsPreviewLayerRebuild {
+      requiresPreviewLayerRebuildForOrientationChange = false
+      logDebug("프리뷰 레이어 재생성: \(geometryKey)", category: .camera)
+      previewLayer?.removeFromSuperlayer()
+      previewLayer = nil
+      setupAVFoundationPreview(with: session)
+      return
+    }
+
+    logDebug("프리뷰 레이어 지오메트리 업데이트: \(geometryKey)", category: .camera)
+    updatePreviewPresentation(forceConnectionRefresh: true)
+  }
+
+  private func updatePreviewPresentation(forceConnectionRefresh: Bool = false) {
+    guard Thread.isMainThread else {
+      DispatchQueue.main.async { [weak self] in
+        self?.updatePreviewPresentation(forceConnectionRefresh: forceConnectionRefresh)
+      }
+      return
+    }
+
+    let previewFrame = calculatePreviewFrame(in: bounds)
+
+    CATransaction.begin()
+    CATransaction.setDisableActions(true)
+    previewLayer?.bounds = previewLayerBounds(for: previewFrame)
+    previewLayer?.position = CGPoint(x: previewFrame.midX, y: previewFrame.midY)
+    hkPreviewLayer?.frame = previewFrame
+    applyPreviewConnectionOrientation(to: previewLayer?.connection)
+    previewLayer?.setAffineTransform(CGAffineTransform(rotationAngle: previewVisualRotationAngle))
+    CATransaction.commit()
+
+    logPreviewDebugSnapshot(context: "updatePreviewPresentation")
+
+    refreshVideoOutputConnectionIfNeeded(force: forceConnectionRefresh)
+  }
+
+  private func previewLayerPointToDevicePoint(_ point: CGPoint) -> CGPoint {
+    guard let previewLayer else {
+      let x = bounds.width > 0 ? point.x / bounds.width : 0.5
+      let y = bounds.height > 0 ? point.y / bounds.height : 0.5
+      return CGPoint(x: x, y: y)
+    }
+
+    let layerPoint = layer.convert(point, to: previewLayer)
+    return previewLayer.captureDevicePointConverted(fromLayerPoint: layerPoint)
+  }
+
   // MARK: - Preview Layer Management
 
   private func updatePreviewLayer() {
+    invalidatePreviewGeometryConfigCache()
     // 기존 레이어 제거
     previewLayer?.removeFromSuperlayer()
     hkPreviewLayer?.removeFromSuperview()
@@ -303,10 +557,9 @@ final class CameraPreviewUIView: UIView {
         logInfo("프리뷰 레이어 다시 추가", category: .camera)
         self.layer.insertSublayer(layer, at: 0)
       }
-
-      // 프레임 업데이트
-      layer.frame = bounds
     }
+
+    refreshPreviewLayerGeometryIfNeeded(force: true)
 
     logDebug("프리뷰 레이어 보호 완료", category: .camera)
   }
@@ -320,6 +573,7 @@ final class CameraPreviewUIView: UIView {
       return
     }
     updateFrameConsumerRegistration()
+    invalidatePreviewGeometryConfigCache()
     invalidateVideoOutputConnectionConfigCache()
     refreshVideoOutputConnectionIfNeeded(force: true)
   }
@@ -328,47 +582,17 @@ final class CameraPreviewUIView: UIView {
   private func syncVideoOutputConnection() {
     guard let frameRouter else { return }
 
-    if let previewConnection = previewLayer?.connection {
-      if #available(iOS 17.0, *) {
-        frameRouter.syncPreviewVideoOutputConnection(
-          rotationAngle: previewConnection.videoRotationAngle,
-          orientation: nil,
-          isMirrored: previewConnection.isVideoMirroringSupported
-            ? previewConnection.isVideoMirrored : false
-        )
-      } else {
-        let legacyOrientation: PreviewVideoOrientation
-        switch previewConnection.videoOrientation {
-        case .portrait:
-          legacyOrientation = .portrait
-        case .portraitUpsideDown:
-          legacyOrientation = .portraitUpsideDown
-        case .landscapeRight:
-          legacyOrientation = .landscapeRight
-        case .landscapeLeft:
-          legacyOrientation = .landscapeLeft
-        @unknown default:
-          legacyOrientation = .portrait
-        }
-        frameRouter.syncPreviewVideoOutputConnection(
-          rotationAngle: nil,
-          orientation: legacyOrientation,
-          isMirrored: previewConnection.isVideoMirroringSupported
-            ? previewConnection.isVideoMirrored : false
-        )
-      }
-      return
-    }
-
     let currentDevice = getCurrentCameraDevice()
     let isExternalCamera = currentDevice?.deviceType == .external
     let isFrontCamera = currentDevice?.position == .front
-    let isMirrored = !isExternalCamera && isFrontCamera
+    let previewMirrored = previewLayer?.connection?.isVideoMirroringSupported == true
+      ? (previewLayer?.connection?.isVideoMirrored ?? false)
+      : (!isExternalCamera && isFrontCamera)
 
     frameRouter.syncPreviewVideoOutputConnection(
-      rotationAngle: 0,
-      orientation: .portrait,
-      isMirrored: isMirrored
+      rotationAngle: videoOutputRotationAngle,
+      orientation: videoOutputOrientation,
+      isMirrored: previewMirrored
     )
   }
 
@@ -404,6 +628,8 @@ final class CameraPreviewUIView: UIView {
     } else {
       keyComponents.append("preview:none")
     }
+
+    keyComponents.append("streamOrientation:\(activeStreamingSettings.streamOrientation.rawValue)")
 
     if let currentDevice = getCurrentCameraDevice() {
       keyComponents.append("device:\(currentDevice.uniqueID)")
@@ -538,36 +764,15 @@ final class CameraPreviewUIView: UIView {
     logInfo("AVFoundation 프리뷰 레이어 설정 중...", category: .camera)
 
     let newPreviewLayer = AVCaptureVideoPreviewLayer(session: session)
+    let previewFrame = calculatePreviewFrame(in: bounds)
+    newPreviewLayer.bounds = previewLayerBounds(for: previewFrame)
+    newPreviewLayer.position = CGPoint(x: previewFrame.midX, y: previewFrame.midY)
 
-    // 16:9 비율 계산 및 적용
-    let aspectRatio: CGFloat = 16.0 / 9.0
-    let viewBounds = bounds
+    // 프리뷰는 카메라 원본 방향을 유지하고 남는 영역은 검은색으로 둡니다.
+    newPreviewLayer.videoGravity = .resizeAspect
 
-    // 16:9 비율에 맞는 프레임 계산
-    let previewFrame: CGRect
-    if viewBounds.width / viewBounds.height > aspectRatio {
-      // 세로가 기준: 높이에 맞춰서 너비 계산
-      let width = viewBounds.height * aspectRatio
-      let offsetX = (viewBounds.width - width) / 2
-      previewFrame = CGRect(x: offsetX, y: 0, width: width, height: viewBounds.height)
-    } else {
-      // 가로가 기준: 너비에 맞춰서 높이 계산
-      let height = viewBounds.width / aspectRatio
-      let offsetY = (viewBounds.height - height) / 2
-      previewFrame = CGRect(x: 0, y: offsetY, width: viewBounds.width, height: height)
-    }
-
-    newPreviewLayer.frame = previewFrame
-
-    // 실제 송출 영역과 일치: resizeAspectFill 사용
-    // 카메라 이미지가 프레임을 완전히 채우도록 설정
-    newPreviewLayer.videoGravity = .resizeAspectFill
-
-    if #available(iOS 17.0, *) {
-      newPreviewLayer.connection?.videoRotationAngle = 0
-    } else {
-      newPreviewLayer.connection?.videoOrientation = .portrait
-    }
+    applyPreviewConnectionOrientation(to: newPreviewLayer.connection)
+    newPreviewLayer.setAffineTransform(.identity)
 
     // 🔄 카메라 타입에 따른 미러링 설정 (외장 카메라 좌우 반전 문제 해결)
     if let connection = newPreviewLayer.connection {
@@ -607,62 +812,93 @@ final class CameraPreviewUIView: UIView {
 
     layer.insertSublayer(newPreviewLayer, at: 0)
     previewLayer = newPreviewLayer
+    previewGeometryConfigKey = makePreviewGeometryConfigKey()
     invalidateVideoOutputConnectionConfigCache()
-    refreshVideoOutputConnectionIfNeeded()
+    updatePreviewPresentation(forceConnectionRefresh: true)
+    logPreviewDebugSnapshot(context: "setupAVFoundationPreview")
 
     logInfo("AVFoundation 프리뷰 레이어 설정 완료", category: .camera)
-    logDebug("16:9 비율 프레임: \(previewFrame)", category: .camera)
-    logDebug("videoGravity: resizeAspectFill (송출 영역과 일치)", category: .camera)
+    logDebug("송출 비율 프레임: \(previewFrame)", category: .camera)
+    logDebug("videoGravity: resizeAspect (카메라 원본 비율 유지)", category: .camera)
   }
+
+  #if DEBUG
+    private func logPreviewDebugSnapshot(context: String) {
+      let previewFrame = calculatePreviewFrame(in: bounds)
+      let connectionDescription: String = {
+        guard let connection = previewLayer?.connection else { return "none" }
+
+        if #available(iOS 17.0, *) {
+          return "angle=\(Int(connection.videoRotationAngle))"
+        }
+
+        return "orientation=\(connection.videoOrientation.rawValue)"
+      }()
+
+      let snapshot = [
+        "context=\(context)",
+        "stream=\(activeStreamingSettings.streamOrientation.rawValue)",
+        "interface=\(currentInterfaceOrientation?.rawValue ?? -1)",
+        "previewFrame=\(Int(previewFrame.width))x\(Int(previewFrame.height))",
+        "layerBounds=\(Int(previewLayer?.bounds.width ?? 0))x\(Int(previewLayer?.bounds.height ?? 0))",
+        "visualTurn=\(previewNeedsVisualQuarterTurn)",
+        "visualAngle=\(Int(previewVisualRotationAngle * 180 / .pi))",
+        "connection=\(connectionDescription)",
+      ].joined(separator: " | ")
+
+      guard snapshot != lastPreviewDebugSnapshot else { return }
+      lastPreviewDebugSnapshot = snapshot
+
+      let message = "\(ISO8601DateFormatter().string(from: Date())) | \(snapshot)\n"
+      persistPreviewDebugMessage(message)
+      logDebug("프리뷰 디버그: \(snapshot)", category: .camera)
+    }
+
+    private func persistPreviewDebugMessage(_ message: String) {
+      DispatchQueue.global(qos: .utility).async {
+        guard
+          let documentsURL = FileManager.default.urls(
+            for: .documentDirectory,
+            in: .userDomainMask
+          ).first
+        else {
+          return
+        }
+
+        let fileURL = documentsURL.appendingPathComponent("preview-debug.log")
+        let data = Data(message.utf8)
+
+        if FileManager.default.fileExists(atPath: fileURL.path) == false {
+          try? data.write(to: fileURL, options: .atomic)
+          return
+        }
+
+        if let handle = try? FileHandle(forWritingTo: fileURL) {
+          defer { try? handle.close() }
+          try? handle.seekToEnd()
+          try? handle.write(contentsOf: data)
+        }
+      }
+    }
+  #else
+    private func logPreviewDebugSnapshot(context: String) {}
+  #endif
 
   override func layoutSubviews() {
     super.layoutSubviews()
+    refreshPreviewLayerGeometryIfNeeded()
+  }
 
-    // 프리뷰 레이어 프레임 업데이트 (16:9 비율 유지)
-    DispatchQueue.main.async { [weak self] in
-      guard let self = self else { return }
-
-      // 16:9 비율 계산
-      let aspectRatio: CGFloat = 16.0 / 9.0
-      let viewBounds = self.bounds
-
-      // 16:9 비율에 맞는 프레임 재계산
-      let previewFrame: CGRect
-      if viewBounds.width / viewBounds.height > aspectRatio {
-        // 세로가 기준: 높이에 맞춰서 너비 계산
-        let width = viewBounds.height * aspectRatio
-        let offsetX = (viewBounds.width - width) / 2
-        previewFrame = CGRect(x: offsetX, y: 0, width: width, height: viewBounds.height)
-      } else {
-        // 가로가 기준: 너비에 맞춰서 높이 계산
-        let height = viewBounds.width / aspectRatio
-        let offsetY = (viewBounds.height - height) / 2
-        previewFrame = CGRect(x: 0, y: offsetY, width: viewBounds.width, height: height)
-      }
-
-      // 프리뷰 레이어 프레임 업데이트 (16:9 비율 적용)
-      self.previewLayer?.frame = previewFrame
-      self.hkPreviewLayer?.frame = previewFrame
-
-      // 레이어가 올바르게 표시되도록 강제 레이아웃 업데이트
-      if let layer = self.previewLayer {
-        layer.setNeedsLayout()
-        layer.layoutIfNeeded()
-      }
-
-      self.refreshVideoOutputConnectionIfNeeded()
-      logDebug("레이아웃 업데이트 - 16:9 프레임: \(previewFrame)", category: .camera)
-    }
+  override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+    super.traitCollectionDidChange(previousTraitCollection)
+    refreshPreviewLayerGeometryIfNeeded(force: true)
   }
 
   // MARK: - Gesture Handlers
 
   @objc private func handleFocusTap(_ gesture: UITapGestureRecognizer) {
     let point = gesture.location(in: self)
-    let focusPoint = CGPoint(
-      x: point.x / bounds.width,
-      y: point.y / bounds.height
-    )
+    let focusPoint = previewLayerPointToDevicePoint(point)
 
     setFocusPoint(focusPoint)
     showFocusIndicator(at: point)
@@ -670,10 +906,7 @@ final class CameraPreviewUIView: UIView {
 
   @objc private func handleExposureDoubleTap(_ gesture: UITapGestureRecognizer) {
     let point = gesture.location(in: self)
-    let exposurePoint = CGPoint(
-      x: point.x / bounds.width,
-      y: point.y / bounds.height
-    )
+    let exposurePoint = previewLayerPointToDevicePoint(point)
 
     setExposurePoint(exposurePoint)
     showExposureIndicator(at: point)

--- a/USBExternalCamera/Views/Camera/CameraPreviewUIView.swift
+++ b/USBExternalCamera/Views/Camera/CameraPreviewUIView.swift
@@ -13,6 +13,11 @@ import LiveStreamingCore
 
 /// 실제 카메라 미리보기를 담당하는 UIView
 final class CameraPreviewUIView: UIView {
+  #if DEBUG
+    private static let isPreviewDebugLoggingEnabled =
+      ProcessInfo.processInfo.arguments.contains("--preview-debug-log")
+      || UserDefaults.standard.bool(forKey: "Debug.previewDebugLoggingEnabled")
+  #endif
 
   // MARK: - Properties
 
@@ -70,15 +75,7 @@ final class CameraPreviewUIView: UIView {
   var streamingSettings: LiveStreamSettings? {
     didSet {
       guard hasMeaningfulStreamingSettingChange(from: oldValue, to: streamingSettings) else { return }
-      let orientationChanged = oldValue?.streamOrientation != streamingSettings?.streamOrientation
-      DispatchQueue.main.async { [weak self] in
-        guard let self else { return }
-        if orientationChanged {
-          self.requiresPreviewLayerRebuildForOrientationChange = true
-        }
-        self.invalidateVideoOutputConnectionConfigCache()
-        self.refreshPreviewLayerGeometryIfNeeded(force: true)
-      }
+      requestPreviewPresentationUpdate(forceConnectionRefresh: false)
     }
   }
 
@@ -94,8 +91,14 @@ final class CameraPreviewUIView: UIView {
   /// 프리뷰 레이어 지오메트리 재구성 캐시 키
   private var previewGeometryConfigKey: String?
 
-  /// 가로/세로 전환 시 AVFoundation 프리뷰 레이어 재생성이 필요한지 여부
-  private var requiresPreviewLayerRebuildForOrientationChange = false
+  /// 프리뷰 레이어 지오메트리 갱신 작업 (중복 스케줄 방지)
+  private var pendingPreviewPresentationUpdate: DispatchWorkItem?
+
+  /// 프리뷰 갱신 시 비디오 output sync까지 함께 요청할지 여부
+  private var pendingPreviewConnectionRefresh = false
+
+  /// 회전 중 발생하는 중간 레이아웃 변화를 한 번으로 합치기 위한 짧은 지연
+  private let previewPresentationDebounceInterval: TimeInterval = 0.03
 
   #if DEBUG
     /// 마지막으로 기록한 프리뷰 디버그 스냅샷
@@ -153,13 +156,13 @@ final class CameraPreviewUIView: UIView {
     updateFrameConsumerRegistration()
   }
 
-  private func updateFrameConsumerRegistration() {
+  func updateFrameConsumerRegistration() {
     guard let frameRouter else {
       isFrameConsumerRegistered = false
       return
     }
 
-    if window != nil {
+    if window != nil && isScreenCapturing {
       guard !isFrameConsumerRegistered else { return }
       frameRouter.addPreviewFrameConsumer(screenCaptureFrameConsumer)
       isFrameConsumerRegistered = true
@@ -387,6 +390,7 @@ final class CameraPreviewUIView: UIView {
       "bounds:\(roundedPreviewDimension(bounds.width))x\(roundedPreviewDimension(bounds.height))",
       "preview:\(roundedPreviewDimension(previewFrame.width))x\(roundedPreviewDimension(previewFrame.height))",
       "stream:\(activeStreamingSettings.streamOrientation.rawValue)",
+      "interface:\(interfaceOrientation)",
       "session:\(sessionIdentifier)",
     ].joined(separator: "|")
   }
@@ -395,53 +399,57 @@ final class CameraPreviewUIView: UIView {
     previewGeometryConfigKey = nil
   }
 
-  private func refreshPreviewLayerGeometryIfNeeded(force: Bool = false) {
+  private func requestPreviewPresentationUpdate(forceConnectionRefresh: Bool = false) {
     guard Thread.isMainThread else {
       DispatchQueue.main.async { [weak self] in
-        self?.refreshPreviewLayerGeometryIfNeeded(force: force)
+        self?.requestPreviewPresentationUpdate(forceConnectionRefresh: forceConnectionRefresh)
       }
       return
     }
 
+    if forceConnectionRefresh {
+      pendingPreviewConnectionRefresh = true
+    }
+
+    pendingPreviewPresentationUpdate?.cancel()
+
+    let workItem = DispatchWorkItem { [weak self] in
+      guard let self else { return }
+      self.pendingPreviewPresentationUpdate = nil
+      self.performPreviewPresentationUpdate()
+    }
+
+    pendingPreviewPresentationUpdate = workItem
+    let delay = forceConnectionRefresh ? 0 : previewPresentationDebounceInterval
+    DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: workItem)
+  }
+
+  private func performPreviewPresentationUpdate() {
+    guard Thread.isMainThread else {
+      DispatchQueue.main.async { [weak self] in
+        self?.performPreviewPresentationUpdate()
+      }
+      return
+    }
+
+    let forceConnectionRefresh = pendingPreviewConnectionRefresh
+    pendingPreviewConnectionRefresh = false
+
     guard let session = captureSession else { return }
 
+    let previewFrame = calculatePreviewFrame(in: bounds)
     let geometryKey = makePreviewGeometryConfigKey()
     let needsPreviewLayerRebuild =
       previewLayer == nil
       || previewLayer?.session !== session
-      || requiresPreviewLayerRebuildForOrientationChange
 
-    guard force || needsPreviewLayerRebuild || previewGeometryConfigKey != geometryKey else {
-      updatePreviewPresentation(forceConnectionRefresh: force)
+    guard forceConnectionRefresh || needsPreviewLayerRebuild || previewGeometryConfigKey != geometryKey else {
       return
     }
-
-    previewGeometryConfigKey = geometryKey
-    if needsPreviewLayerRebuild {
-      requiresPreviewLayerRebuildForOrientationChange = false
-      logDebug("프리뷰 레이어 재생성: \(geometryKey)", category: .camera)
-      previewLayer?.removeFromSuperlayer()
-      previewLayer = nil
-      setupAVFoundationPreview(with: session)
-      return
-    }
-
-    logDebug("프리뷰 레이어 지오메트리 업데이트: \(geometryKey)", category: .camera)
-    updatePreviewPresentation(forceConnectionRefresh: true)
-  }
-
-  private func updatePreviewPresentation(forceConnectionRefresh: Bool = false) {
-    guard Thread.isMainThread else {
-      DispatchQueue.main.async { [weak self] in
-        self?.updatePreviewPresentation(forceConnectionRefresh: forceConnectionRefresh)
-      }
-      return
-    }
-
-    let previewFrame = calculatePreviewFrame(in: bounds)
 
     CATransaction.begin()
     CATransaction.setDisableActions(true)
+    previewGeometryConfigKey = geometryKey
     previewLayer?.bounds = previewLayerBounds(for: previewFrame)
     previewLayer?.position = CGPoint(x: previewFrame.midX, y: previewFrame.midY)
     hkPreviewLayer?.frame = previewFrame
@@ -469,6 +477,8 @@ final class CameraPreviewUIView: UIView {
 
   private func updatePreviewLayer() {
     invalidatePreviewGeometryConfigCache()
+    pendingPreviewPresentationUpdate?.cancel()
+    pendingPreviewPresentationUpdate = nil
     // 기존 레이어 제거
     previewLayer?.removeFromSuperlayer()
     hkPreviewLayer?.removeFromSuperview()
@@ -559,7 +569,7 @@ final class CameraPreviewUIView: UIView {
       }
     }
 
-    refreshPreviewLayerGeometryIfNeeded(force: true)
+    requestPreviewPresentationUpdate(forceConnectionRefresh: false)
 
     logDebug("프리뷰 레이어 보호 완료", category: .camera)
   }
@@ -629,8 +639,6 @@ final class CameraPreviewUIView: UIView {
       keyComponents.append("preview:none")
     }
 
-    keyComponents.append("streamOrientation:\(activeStreamingSettings.streamOrientation.rawValue)")
-
     if let currentDevice = getCurrentCameraDevice() {
       keyComponents.append("device:\(currentDevice.uniqueID)")
       keyComponents.append("position:\(currentDevice.position.rawValue)")
@@ -692,7 +700,6 @@ final class CameraPreviewUIView: UIView {
 
     // 연결 상태에 따른 상세 UI 업데이트
     DispatchQueue.main.async { [weak self] in
-      self?.refreshVideoOutputConnectionIfNeeded()
       self?.updateDetailedStreamingStatus(
         isStreaming: newStreamingState,
         connectionStatus: connectionStatus,
@@ -725,6 +732,7 @@ final class CameraPreviewUIView: UIView {
   /// 정리 작업
   deinit {
     statusMonitorTimer?.invalidate()
+    pendingPreviewPresentationUpdate?.cancel()
     NotificationCenter.default.removeObserver(self)
     // textOverlayLabel 제거됨 - SwiftUI에서 관리
   }
@@ -814,7 +822,8 @@ final class CameraPreviewUIView: UIView {
     previewLayer = newPreviewLayer
     previewGeometryConfigKey = makePreviewGeometryConfigKey()
     invalidateVideoOutputConnectionConfigCache()
-    updatePreviewPresentation(forceConnectionRefresh: true)
+    pendingPreviewConnectionRefresh = true
+    performPreviewPresentationUpdate()
     logPreviewDebugSnapshot(context: "setupAVFoundationPreview")
 
     logInfo("AVFoundation 프리뷰 레이어 설정 완료", category: .camera)
@@ -824,6 +833,8 @@ final class CameraPreviewUIView: UIView {
 
   #if DEBUG
     private func logPreviewDebugSnapshot(context: String) {
+      guard Self.isPreviewDebugLoggingEnabled else { return }
+
       let previewFrame = calculatePreviewFrame(in: bounds)
       let connectionDescription: String = {
         guard let connection = previewLayer?.connection else { return "none" }
@@ -886,12 +897,17 @@ final class CameraPreviewUIView: UIView {
 
   override func layoutSubviews() {
     super.layoutSubviews()
-    refreshPreviewLayerGeometryIfNeeded()
+    requestPreviewPresentationUpdate(forceConnectionRefresh: false)
   }
 
   override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
     super.traitCollectionDidChange(previousTraitCollection)
-    refreshPreviewLayerGeometryIfNeeded(force: true)
+    let horizontalSizeClassChanged =
+      previousTraitCollection?.horizontalSizeClass != traitCollection.horizontalSizeClass
+    let verticalSizeClassChanged =
+      previousTraitCollection?.verticalSizeClass != traitCollection.verticalSizeClass
+    guard horizontalSizeClassChanged || verticalSizeClassChanged else { return }
+    requestPreviewPresentationUpdate(forceConnectionRefresh: false)
   }
 
   // MARK: - Gesture Handlers

--- a/USBExternalCamera/Views/Camera/CameraPreviewView.swift
+++ b/USBExternalCamera/Views/Camera/CameraPreviewView.swift
@@ -16,7 +16,7 @@ import LiveStreamingCore
 struct CameraPreviewView: UIViewRepresentable {
   let session: AVCaptureSession
   let cameraViewModel: CameraPreviewFrameRouting
-  var streamViewModel: LiveStreamViewModel?
+  let streamingSettings: LiveStreamSettings
   var haishinKitManager: HaishinKitManager?
 
   // 텍스트 오버레이 관련 프로퍼티
@@ -26,14 +26,14 @@ struct CameraPreviewView: UIViewRepresentable {
   init(
     session: AVCaptureSession,
     cameraViewModel: CameraPreviewFrameRouting,
-    streamViewModel: LiveStreamViewModel? = nil,
+    streamingSettings: LiveStreamSettings,
     haishinKitManager: HaishinKitManager? = nil,
     showTextOverlay: Bool = false,
     overlayText: String = ""
   ) {
     self.session = session
     self.cameraViewModel = cameraViewModel
-    self.streamViewModel = streamViewModel
+    self.streamingSettings = streamingSettings
     self.haishinKitManager = haishinKitManager
     self.showTextOverlay = showTextOverlay
     self.overlayText = overlayText
@@ -44,20 +44,9 @@ struct CameraPreviewView: UIViewRepresentable {
     view.captureSession = session
     view.frameRouter = cameraViewModel
     view.haishinKitManager = haishinKitManager
+    view.streamingSettings = streamingSettings
     view.showTextOverlay = showTextOverlay
     view.overlayText = overlayText
-
-    // 여백을 4픽셀로 설정하고 화면에 꽉차게 설정
-    view.translatesAutoresizingMaskIntoConstraints = false
-    NSLayoutConstraint.activate([
-      view.topAnchor.constraint(equalTo: view.superview?.topAnchor ?? view.topAnchor, constant: 4),
-      view.bottomAnchor.constraint(
-        equalTo: view.superview?.bottomAnchor ?? view.bottomAnchor, constant: -4),
-      view.leadingAnchor.constraint(
-        equalTo: view.superview?.leadingAnchor ?? view.leadingAnchor, constant: 4),
-      view.trailingAnchor.constraint(
-        equalTo: view.superview?.trailingAnchor ?? view.trailingAnchor, constant: -4),
-    ])
 
     return view
   }
@@ -70,20 +59,22 @@ struct CameraPreviewView: UIViewRepresentable {
       let textOverlayChanged =
         previewView.showTextOverlay != showTextOverlay || previewView.overlayText != overlayText
 
+      previewView.streamingSettings = streamingSettings
+
       if sessionChanged {
-        logInfo("캡처 세션 변경 감지 - 업데이트", category: .camera)
+        logDebug("캡처 세션 변경 감지 - 업데이트", category: .camera)
         previewView.captureSession = session
       }
 
       previewView.frameRouter = cameraViewModel
 
       if managerChanged {
-        logInfo("HaishinKit 매니저 변경 감지 - 업데이트", category: .camera)
+        logDebug("HaishinKit 매니저 변경 감지 - 업데이트", category: .camera)
         previewView.haishinKitManager = haishinKitManager
       }
 
       if textOverlayChanged {
-        logInfo("텍스트 오버레이 변경 감지 - 업데이트", category: .camera)
+        logDebug("텍스트 오버레이 변경 감지 - 업데이트", category: .camera)
         previewView.showTextOverlay = showTextOverlay
         previewView.overlayText = overlayText
 
@@ -92,9 +83,6 @@ struct CameraPreviewView: UIViewRepresentable {
           haishinKitManager.updateTextOverlay(show: showTextOverlay, text: overlayText)
         }
       }
-
-      // 프리뷰 새로고침은 하지 않음 (안정성 향상)
-      logInfo("업데이트 완료 - 프리뷰 새로고침 건너뜀", category: .camera)
     }
   }
 

--- a/USBExternalCamera/Views/Camera/CameraRenderingHelpers.swift
+++ b/USBExternalCamera/Views/Camera/CameraRenderingHelpers.swift
@@ -22,6 +22,18 @@ private enum CameraStreamingCompositionContext {
 // MARK: - Rendering Helpers Extension for CameraPreviewUIView
 
 extension CameraPreviewUIView {
+  private func makeStreamingOverlaySnapshotCacheKey(streamingSize: CGSize) -> String {
+    let previewBounds = bounds.integral.size
+    let safeArea = safeAreaInsets
+    return [
+      "stream:\(Int(streamingSize.width))x\(Int(streamingSize.height))",
+      "bounds:\(Int(previewBounds.width))x\(Int(previewBounds.height))",
+      "safe:\(Int(safeArea.top))|\(Int(safeArea.left))|\(Int(safeArea.bottom))|\(Int(safeArea.right))",
+      "subviews:\(subviews.count)",
+      "streaming:\(haishinKitManager?.isStreaming == true)",
+    ].joined(separator: "|")
+  }
+
   private func orientedCameraImageForStreaming(_ image: CIImage) -> CIImage {
     image
   }
@@ -34,6 +46,13 @@ extension CameraPreviewUIView {
     let width = Int(streamingSize.width)
     let height = Int(streamingSize.height)
     guard width > 0, height > 0 else { return nil }
+
+    let cacheKey = makeStreamingOverlaySnapshotCacheKey(streamingSize: streamingSize)
+    if cachedStreamingOverlaySnapshotKey == cacheKey,
+       let cachedSnapshot = cachedStreamingOverlaySnapshot
+    {
+      return cachedSnapshot
+    }
 
     let colorSpace = CGColorSpaceCreateDeviceRGB()
     let bitmapInfo = CGImageAlphaInfo.premultipliedFirst.rawValue
@@ -75,7 +94,10 @@ extension CameraPreviewUIView {
       subview.layer.render(in: context)
     }
 
-    return context.makeImage()
+    let snapshot = context.makeImage()
+    cachedStreamingOverlaySnapshotKey = cacheKey
+    cachedStreamingOverlaySnapshot = snapshot
+    return snapshot
   }
 
   func composeStreamingPixelBuffer(

--- a/USBExternalCamera/Views/Camera/CameraRenderingHelpers.swift
+++ b/USBExternalCamera/Views/Camera/CameraRenderingHelpers.swift
@@ -22,6 +22,14 @@ private enum CameraStreamingCompositionContext {
 // MARK: - Rendering Helpers Extension for CameraPreviewUIView
 
 extension CameraPreviewUIView {
+  private func orientedCameraImageForStreaming(_ image: CIImage) -> CIImage {
+    image
+  }
+
+  private func orientedUIImageForCurrentStream(_ image: UIImage) -> UIImage {
+    image
+  }
+
   func makeStreamingOverlaySnapshot(streamingSize: CGSize) -> CGImage? {
     let width = Int(streamingSize.width)
     let height = Int(streamingSize.height)
@@ -84,11 +92,14 @@ extension CameraPreviewUIView {
     }
 
     let backgroundImage: CIImage
+    let backgroundCanvas = CIImage(color: CIColor(red: 0, green: 0, blue: 0, alpha: 1))
+      .cropped(to: CGRect(origin: .zero, size: streamingSize))
     if let cameraFrame {
-      backgroundImage = aspectFillImage(CIImage(cvPixelBuffer: cameraFrame), targetSize: streamingSize)
+      let sourceImage = orientedCameraImageForStreaming(CIImage(cvPixelBuffer: cameraFrame))
+      backgroundImage = aspectFitImage(sourceImage, targetSize: streamingSize)
+        .composited(over: backgroundCanvas)
     } else {
-      backgroundImage = CIImage(color: CIColor(red: 0, green: 0, blue: 0, alpha: 1))
-        .cropped(to: CGRect(origin: .zero, size: streamingSize))
+      backgroundImage = backgroundCanvas
     }
 
     let composedImage: CIImage
@@ -130,7 +141,7 @@ extension CameraPreviewUIView {
     return pixelBuffer
   }
 
-  private func aspectFillImage(_ image: CIImage, targetSize: CGSize) -> CIImage {
+  private func aspectFitImage(_ image: CIImage, targetSize: CGSize) -> CIImage {
     let sourceRect = image.extent
     guard sourceRect.width > 0, sourceRect.height > 0 else {
       return image.cropped(to: CGRect(origin: .zero, size: targetSize))
@@ -138,7 +149,7 @@ extension CameraPreviewUIView {
 
     let scaleX = targetSize.width / sourceRect.width
     let scaleY = targetSize.height / sourceRect.height
-    let scale = max(scaleX, scaleY)
+    let scale = min(scaleX, scaleY)
     let scaledWidth = sourceRect.width * scale
     let scaledHeight = sourceRect.height * scale
     let offsetX = (targetSize.width - scaledWidth) / 2.0
@@ -150,6 +161,37 @@ extension CameraPreviewUIView {
           .translatedBy(x: offsetX / scale, y: offsetY / scale)
       )
       .cropped(to: CGRect(origin: .zero, size: targetSize))
+  }
+
+  private func aspectFitRect(for imageSize: CGSize, inside targetRect: CGRect) -> CGRect {
+    guard imageSize.width > 0, imageSize.height > 0, targetRect.width > 0, targetRect.height > 0 else {
+      return targetRect
+    }
+
+    let imageAspectRatio = imageSize.width / imageSize.height
+    let targetAspectRatio = targetRect.width / targetRect.height
+
+    if imageAspectRatio > targetAspectRatio {
+      let drawWidth = targetRect.width
+      let drawHeight = drawWidth / imageAspectRatio
+      let offsetY = targetRect.origin.y + (targetRect.height - drawHeight) / 2
+      return CGRect(
+        x: targetRect.origin.x,
+        y: offsetY,
+        width: drawWidth,
+        height: drawHeight
+      )
+    }
+
+    let drawHeight = targetRect.height
+    let drawWidth = drawHeight * imageAspectRatio
+    let offsetX = targetRect.origin.x + (targetRect.width - drawWidth) / 2
+    return CGRect(
+      x: offsetX,
+      y: targetRect.origin.y,
+      width: drawWidth,
+      height: drawHeight
+    )
   }
 
   /// 송출용 고해상도 카메라 프레임과 UI 합성
@@ -164,10 +206,11 @@ extension CameraPreviewUIView {
   {
 
     // Step 1: 카메라 프레임을 UIImage로 변환
-    guard let cameraImage = cameraFrame.toUIImage() else {
+    guard let rawCameraImage = cameraFrame.toUIImage() else {
       logError("카메라 프레임 → UIImage 변환 실패", category: .performance)
       return nil
     }
+    let cameraImage = orientedUIImageForCurrentStream(rawCameraImage)
     // Step 2: UI 오버레이를 고해상도로 생성 (1:1 → 16:9 비율 강제 변환)
     // 단말 크기에서 송출 크기로 스케일링 비율 계산
     let currentSize = bounds.size
@@ -208,28 +251,10 @@ extension CameraPreviewUIView {
     // UI와 카메라를 동일한 Aspect Fill 변환으로 맞춤
     let scaledCameraRect = mapRectToStreamingSpace(cameraPreviewRect, from: currentSize, to: streamingSize)
 
-      // 카메라 이미지를 스케일된 영역에 맞춰 그리기 (Aspect Fill 방식)
-      // Aspect Fill로 그려서 카메라 이미지가 잘리지 않도록 함
-      let cameraAspectRatio = cameraImage.size.width / cameraImage.size.height
-      let rectAspectRatio = scaledCameraRect.width / scaledCameraRect.height
+      context.cgContext.setFillColor(UIColor.black.cgColor)
+      context.cgContext.fill(rect)
 
-      let drawRect: CGRect
-      if cameraAspectRatio > rectAspectRatio {
-        // 카메라가 더 넓음: 높이를 맞추고 가로는 넘침
-        let drawHeight = scaledCameraRect.height
-        let drawWidth = drawHeight * cameraAspectRatio
-        let offsetX = scaledCameraRect.origin.x + (scaledCameraRect.width - drawWidth) / 2
-        drawRect = CGRect(
-          x: offsetX, y: scaledCameraRect.origin.y, width: drawWidth, height: drawHeight)
-      } else {
-        // 카메라가 더 높음: 너비를 맞추고 세로는 넘침
-        let drawWidth = scaledCameraRect.width
-        let drawHeight = drawWidth / cameraAspectRatio
-        let offsetY = scaledCameraRect.origin.y + (scaledCameraRect.height - drawHeight) / 2
-        drawRect = CGRect(
-          x: scaledCameraRect.origin.x, y: offsetY, width: drawWidth, height: drawHeight)
-      }
-
+      let drawRect = aspectFitRect(for: cameraImage.size, inside: scaledCameraRect)
       cameraImage.draw(in: drawRect)
 
       // 3-2: UI 오버레이를 전체 화면에 합성
@@ -266,16 +291,16 @@ extension CameraPreviewUIView {
     return mappedRect
   }
 
-  /// 단말 화면에서 카메라 프리뷰가 차지하는 16:9 영역 계산
-  ///
-  /// 실제 송출되는 16:9 비율 영역을 계산합니다.
+  /// 단말 화면에서 카메라 프리뷰가 차지하는 송출 비율 영역 계산
   /// 이를 통해 프리뷰와 송출 화면이 정확히 일치하도록 합니다.
   ///
   /// - Parameter containerSize: 컨테이너 뷰의 크기 (단말 화면 크기)
-  /// - Returns: 16:9 비율로 계산된 카메라 프리뷰 영역
+  /// - Returns: 현재 송출 비율로 계산된 카메라 프리뷰 영역
   func calculateCameraPreviewRect(in containerSize: CGSize) -> CGRect {
-    // 16:9 비율로 고정된 송출 영역 계산
-    let aspectRatio: CGFloat = 16.0 / 9.0
+    let settings = streamingSettings ?? haishinKitManager?.getCurrentSettings() ?? LiveStreamSettings()
+    let aspectRatio = settings.streamAspectRatio > 0
+      ? settings.streamAspectRatio
+      : settings.streamLayoutProfile.aspectRatio
 
     let previewFrame: CGRect
     if containerSize.width / containerSize.height > aspectRatio {
@@ -290,7 +315,7 @@ extension CameraPreviewUIView {
       previewFrame = CGRect(x: 0, y: offsetY, width: containerSize.width, height: height)
     }
 
-    logDebug("16:9 비율 송출 영역: \(previewFrame)", category: .camera)
+    logDebug("송출 비율 영역: \(previewFrame)", category: .camera)
     return previewFrame
   }
 
@@ -453,10 +478,11 @@ extension CameraPreviewUIView {
   func renderCameraFrameWithUI(cameraFrame: CVPixelBuffer, viewSize: CGSize) -> UIImage? {
 
     // Step 1: 카메라 프레임을 UIImage로 변환
-    guard let cameraImage = cameraFrame.toUIImage() else {
+    guard let rawCameraImage = cameraFrame.toUIImage() else {
       logError("카메라 프레임 → UIImage 변환 실패", category: .performance)
       return nil
     }
+    let cameraImage = orientedUIImageForCurrentStream(rawCameraImage)
     logDebug("카메라 이미지 변환 성공: \(cameraImage.size)", category: .performance)
 
     // Step 2: UI 오버레이 생성 (카메라 프리뷰 레이어 제외)
@@ -476,26 +502,10 @@ extension CameraPreviewUIView {
     let compositeImage = finalRenderer.image { context in
       let rect = CGRect(origin: .zero, size: viewSize)
 
-      // 3-1: 카메라 이미지를 뷰 크기에 맞게 그리기 (aspect fill 적용)
-      // Aspect Fill: 원본 비율을 유지하면서 전체 영역을 채움 (일부 잘림 가능하지만 화면 꽉 채움)
-      let cameraAspectRatio = cameraImage.size.width / cameraImage.size.height
-      let rectAspectRatio = rect.width / rect.height
+      context.cgContext.setFillColor(UIColor.black.cgColor)
+      context.cgContext.fill(rect)
 
-      let drawRect: CGRect
-      if cameraAspectRatio > rectAspectRatio {
-        // 카메라가 더 넓음: 높이를 맞추고 가로는 넘침
-        let drawHeight = rect.height
-        let drawWidth = drawHeight * cameraAspectRatio
-        let offsetX = (rect.width - drawWidth) / 2
-        drawRect = CGRect(x: offsetX, y: 0, width: drawWidth, height: drawHeight)
-      } else {
-        // 카메라가 더 높음: 너비를 맞추고 세로는 넘침
-        let drawWidth = rect.width
-        let drawHeight = drawWidth / cameraAspectRatio
-        let offsetY = (rect.height - drawHeight) / 2
-        drawRect = CGRect(x: 0, y: offsetY, width: drawWidth, height: drawHeight)
-      }
-
+      let drawRect = aspectFitRect(for: cameraImage.size, inside: rect)
       cameraImage.draw(in: drawRect)
 
       // 3-2: UI 오버레이를 전체 화면에 합성
@@ -507,15 +517,7 @@ extension CameraPreviewUIView {
     return compositeImage
   }
 
-  /// 송출 해상도에 따른 최적 캡처 사이즈 계산 (16:9 비율 고정)
-  ///
-  /// **16:9 비율 강제 적용:**
-  /// - 480p(854x480) → 16:9 비율로 수정 후 2배 업스케일
-  /// - 720p(1280x720) → 2배 업스케일
-  /// - 1080p(1920x1080) → 동일 해상도 캡처
-  /// - 모든 해상도를 16:9 비율로 강제 변환
-  ///
-  /// - Returns: 16:9 비율이 보장된 최적 캡처 해상도
+  /// 송출 해상도에 따른 최적 캡처 사이즈 계산
   func getOptimalCaptureSize() -> CGSize {
     var streamWidth: Int = 0
     var streamHeight: Int = 0
@@ -534,7 +536,7 @@ extension CameraPreviewUIView {
       guard let manager = haishinKitManager,
         let settings = manager.getCurrentSettings()
       else {
-        // 기본값: 720p (16:9 비율)
+        // 기본값: 720p landscape
         return CGSize(width: 1280, height: 720)
       }
 
@@ -542,46 +544,9 @@ extension CameraPreviewUIView {
       streamHeight = settings.videoHeight
     }
 
-    // 16:9 비율 강제 적용 (유튜브 라이브 표준)
-    let aspectRatio: CGFloat = 16.0 / 9.0
-
-    // 송출 해상도를 16:9 비율로 수정
-    let correctedStreamSize: CGSize
-    let currentAspectRatio = CGFloat(streamWidth) / CGFloat(streamHeight)
-
-    if abs(currentAspectRatio - aspectRatio) > 0.1 {
-      // 비율이 16:9가 아니면 강제로 수정
-      let correctedHeight = CGFloat(streamWidth) / aspectRatio
-      correctedStreamSize = CGSize(width: streamWidth, height: Int(correctedHeight))
-    } else {
-      correctedStreamSize = CGSize(width: streamWidth, height: streamHeight)
-    }
-
-    // 16:9 비율 기반 최적 캡처 해상도 계산
-    let captureSize: CGSize
-    let width = Int(correctedStreamSize.width)
-    let height = Int(correctedStreamSize.height)
-
-    switch (width, height) {
-    case (640...854, 360...480):
-      // 480p 계열: 업스케일 없이 목표 해상도 사용 (프레임 안정성 우선)
-      captureSize = CGSize(width: width, height: height)
-
-    case (1280, 720):
-      // 720p: 업스케일 제거로 렌더링 부하 완화
-      captureSize = CGSize(width: 1280, height: 720)
-
-    case (1920, 1080):
-      // 1080p는 송출 해상도와 동일 크기 유지 (안정성 우선)
-      captureSize = CGSize(width: 1920, height: 1080)
-
-    default:
-      // 사용자 정의: 보정된 목표 해상도 그대로 사용
-      captureSize = CGSize(width: width, height: height)
-    }
-
-    // 1080p 표준 해상도는 그대로 유지해 불필요한 리사이즈 오버헤드를 줄임
-    if Int(captureSize.width) == 1920 && Int(captureSize.height) == 1080 {
+    let captureSize = CGSize(width: streamWidth, height: streamHeight)
+    let resolutionClass = StreamResolutionDescriptor(width: streamWidth, height: streamHeight).resolutionClass
+    if resolutionClass != .custom {
       return captureSize
     }
 

--- a/USBExternalCamera/Views/Camera/CameraScreenCapture.swift
+++ b/USBExternalCamera/Views/Camera/CameraScreenCapture.swift
@@ -20,6 +20,14 @@ private final class PixelBufferReference: @unchecked Sendable {
   }
 }
 
+private final class StreamingOverlaySnapshotReference: NSObject {
+  let image: CGImage
+
+  init(image: CGImage) {
+    self.image = image
+  }
+}
+
 final class ScreenCaptureFrameStore: @unchecked Sendable {
   let processingQueue = DispatchQueue(label: "CameraFrameProcessing", qos: .userInteractive)
 
@@ -346,6 +354,22 @@ extension CameraPreviewUIView {
     }
   }
 
+  /// 마지막으로 로그한 캡처 간격 설정 키
+  var lastLoggedCaptureIntervalConfigurationKey: String? {
+    get {
+      objc_getAssociatedObject(self, &AssociatedKeys.lastLoggedCaptureIntervalConfigurationKey)
+        as? String
+    }
+    set {
+      objc_setAssociatedObject(
+        self,
+        &AssociatedKeys.lastLoggedCaptureIntervalConfigurationKey,
+        newValue,
+        .OBJC_ASSOCIATION_COPY_NONATOMIC
+      )
+    }
+  }
+
   /// 렌더링 중복 실행 방지 플래그 (백프레셔)
   var isFrameRenderInProgress: Bool {
     get {
@@ -409,6 +433,43 @@ extension CameraPreviewUIView {
     }
   }
 
+  /// 최근 생성한 UI 오버레이 스냅샷 캐시 키
+  var cachedStreamingOverlaySnapshotKey: String? {
+    get {
+      objc_getAssociatedObject(self, &AssociatedKeys.cachedStreamingOverlaySnapshotKey) as? String
+    }
+    set {
+      objc_setAssociatedObject(
+        self,
+        &AssociatedKeys.cachedStreamingOverlaySnapshotKey,
+        newValue,
+        .OBJC_ASSOCIATION_COPY_NONATOMIC
+      )
+    }
+  }
+
+  /// 최근 생성한 UI 오버레이 스냅샷 캐시
+  var cachedStreamingOverlaySnapshot: CGImage? {
+    get {
+      (objc_getAssociatedObject(self, &AssociatedKeys.cachedStreamingOverlaySnapshotReference)
+        as? StreamingOverlaySnapshotReference)?.image
+    }
+    set {
+      let reference = newValue.map { StreamingOverlaySnapshotReference(image: $0) }
+      objc_setAssociatedObject(
+        self,
+        &AssociatedKeys.cachedStreamingOverlaySnapshotReference,
+        reference,
+        .OBJC_ASSOCIATION_RETAIN_NONATOMIC
+      )
+    }
+  }
+
+  func clearCachedStreamingOverlaySnapshot() {
+    cachedStreamingOverlaySnapshotKey = nil
+    cachedStreamingOverlaySnapshot = nil
+  }
+
   // MARK: - Screen Capture for Streaming
 
   /// CameraPreviewUIView의 화면 캡처 송출 기능
@@ -457,6 +518,8 @@ extension CameraPreviewUIView {
     lastCameraFrameWarningTime = 0
     lastLoggedCameraFrameSize = .zero
 
+    isScreenCapturing = true
+
     // 화면 캡처 시작 전 카메라 파이프라인 정합성 확보
     if let session = captureSession {
       setupVideoFrameCapture(with: session)
@@ -469,13 +532,14 @@ extension CameraPreviewUIView {
     lastFrameDropLogTime = 0
     lastDisplayLinkTickTimestamp = 0
     lastCaptureDispatchTimestamp = 0
+    lastLoggedCaptureIntervalConfigurationKey = nil
+    clearCachedStreamingOverlaySnapshot()
     frameProcessingQueue.async { [weak self] in
       self?.latestCameraFrame = nil
       self?.latestCameraFrameTimestamp = 0
       self?.hasReceivedCameraFrame = false
     }
 
-    isScreenCapturing = true
     logInfo("화면 캡처 송출 시작", category: .streaming)
     if let target = streamingTargetSize {
       logInfo(
@@ -514,6 +578,9 @@ extension CameraPreviewUIView {
     lastFrameDropLogTime = 0
     lastDisplayLinkTickTimestamp = 0
     lastCaptureDispatchTimestamp = 0
+    lastLoggedCaptureIntervalConfigurationKey = nil
+    clearCachedStreamingOverlaySnapshot()
+    updateFrameConsumerRegistration()
 
     // 메모리 정리: 최근 캡처된 카메라 프레임 제거
     frameProcessingQueue.async { [weak self] in
@@ -668,7 +735,7 @@ extension CameraPreviewUIView {
 
     isFrameSendInProgress = true
     let presentationTime = CMTime(seconds: presentationTimestamp, preferredTimescale: 1_000_000_000)
-    Task { @MainActor [weak self] in
+    Task { [weak self] in
       _ = await manager.enqueueManualFrame(
         pixelBuffer,
         presentationTime: presentationTime,
@@ -676,7 +743,9 @@ extension CameraPreviewUIView {
         compositionTimeMs: compositionTimeMs,
         cameraFrameAgeMs: cameraFrameAgeMs
       )
-      self?.isFrameSendInProgress = false
+      await MainActor.run {
+        self?.isFrameSendInProgress = false
+      }
     }
   }
 
@@ -894,22 +963,42 @@ extension CameraPreviewUIView {
       height: resolved.height
     ).resolutionClass
     let clampedFrameRate = resolvedCaptureFrameRateForCurrentResolution()
+    logCaptureIntervalConfigurationIfNeeded(
+      resolutionClass: resolutionClass,
+      frameRate: clampedFrameRate
+    )
 
     switch resolutionClass {
     case .p720:
-      logInfo("720p 특화 캡처: \(clampedFrameRate)fps 적용", category: .streaming)
       return 1.0 / Double(clampedFrameRate)
 
     case .p1080:
-      // 1080p에서도 설정 FPS를 우선 적용해 스톱모션 체감 완화
-      let optimizedFrameRate = clampedFrameRate
-      logInfo("1080p 특화 캡처: \(optimizedFrameRate)fps 적용", category: .streaming)
-      return 1.0 / Double(optimizedFrameRate)
+      return 1.0 / Double(clampedFrameRate)
 
     case .p480, .p4k, .custom:
-      // 480p: 설정값 기반 처리
       return 1.0 / Double(clampedFrameRate)
     }
+  }
+
+  private func logCaptureIntervalConfigurationIfNeeded(
+    resolutionClass: StreamResolutionClass,
+    frameRate: Int
+  ) {
+    let configurationKey = "\(resolutionClass.rawValue)|\(frameRate)"
+    guard lastLoggedCaptureIntervalConfigurationKey != configurationKey else { return }
+    lastLoggedCaptureIntervalConfigurationKey = configurationKey
+
+    let message: String
+    switch resolutionClass {
+    case .p720:
+      message = "720p 특화 캡처: \(frameRate)fps 적용"
+    case .p1080:
+      message = "1080p 특화 캡처: \(frameRate)fps 적용"
+    case .p480, .p4k, .custom:
+      message = "\(resolutionClass.rawValue) 캡처: \(frameRate)fps 적용"
+    }
+
+    logInfo(message, category: .streaming)
   }
 
   private func maxSupportedCaptureFrameRate(width: Int, height: Int) -> Int {
@@ -1009,12 +1098,14 @@ extension CameraPreviewUIView {
   /// 화면 캡처 타겟 해상도 저장
   func setStreamingTargetSize(_ size: CGSize) {
     streamingTargetSize = size
+    clearCachedStreamingOverlaySnapshot()
     logInfo("화면 캡처 목표 해상도 캐시: \(Int(size.width))×\(Int(size.height))", category: .streaming)
   }
 
   /// 화면 캡처 타겟 해상도 캐시 삭제
   func clearStreamingTargetSize() {
     streamingTargetSize = nil
+    clearCachedStreamingOverlaySnapshot()
     logInfo("화면 캡처 목표 해상도 캐시 삭제", category: .streaming)
   }
 }
@@ -1032,4 +1123,7 @@ private struct AssociatedKeys {
   static var streamingTargetSize: UInt8 = 0
   static var lastCameraFrameWarningTime: UInt8 = 0
   static var screenCaptureStartTime: UInt8 = 0
+  static var cachedStreamingOverlaySnapshotKey: UInt8 = 0
+  static var cachedStreamingOverlaySnapshotReference: UInt8 = 0
+  static var lastLoggedCaptureIntervalConfigurationKey: UInt8 = 0
 }

--- a/USBExternalCamera/Views/Camera/CameraScreenCapture.swift
+++ b/USBExternalCamera/Views/Camera/CameraScreenCapture.swift
@@ -889,36 +889,34 @@ extension CameraPreviewUIView {
   /// 해상도별 최적 캡처 간격 계산 (720p 끊김 개선)
   private func getCaptureIntervalForResolution() -> TimeInterval {
     let resolved = resolveStreamingSizeForDiagnostics()
-    let width = resolved.width
-    let height = resolved.height
+    let resolutionClass = StreamResolutionDescriptor(
+      width: resolved.width,
+      height: resolved.height
+    ).resolutionClass
     let clampedFrameRate = resolvedCaptureFrameRateForCurrentResolution()
 
-    switch (width, height) {
-    case (1280, 720):
+    switch resolutionClass {
+    case .p720:
       logInfo("720p 특화 캡처: \(clampedFrameRate)fps 적용", category: .streaming)
       return 1.0 / Double(clampedFrameRate)
 
-    case (1920, 1080):
+    case .p1080:
       // 1080p에서도 설정 FPS를 우선 적용해 스톱모션 체감 완화
       let optimizedFrameRate = clampedFrameRate
       logInfo("1080p 특화 캡처: \(optimizedFrameRate)fps 적용", category: .streaming)
       return 1.0 / Double(optimizedFrameRate)
 
-    case (640...854, 360...480):
+    case .p480, .p4k, .custom:
       // 480p: 설정값 기반 처리
-      return 1.0 / Double(clampedFrameRate)
-
-    default:
-      // 기타: 설정값 기반 처리
       return 1.0 / Double(clampedFrameRate)
     }
   }
 
   private func maxSupportedCaptureFrameRate(width: Int, height: Int) -> Int {
-    switch (width, height) {
-    case (1280, 720):
+    switch StreamResolutionDescriptor(width: width, height: height).resolutionClass {
+    case .p720:
       return 60
-    default:
+    case .p480, .p1080, .p4k, .custom:
       return 30
     }
   }

--- a/USBExternalCamera/Views/Common/DetailView.swift
+++ b/USBExternalCamera/Views/Common/DetailView.swift
@@ -7,22 +7,33 @@
 
 import SwiftUI
 import LiveStreamingCore
+import Combine
 
 // MARK: - Detail View Components
 
 /// 상세 화면 View 컴포넌트
 /// 선택된 사이드바 항목에 따라 적절한 콘텐츠를 표시하는 컴포넌트입니다.
 struct DetailView: View {
-  @ObservedObject var viewModel: MainViewModel
+  private let viewModel: MainViewModel
+  @StateObject private var detailUIState: DetailUIState
   var onShowSidebar: () -> Void = {}
   @Environment(\.horizontalSizeClass) private var horizontalSizeClass
 
+  init(viewModel: MainViewModel, onShowSidebar: @escaping () -> Void = {}) {
+    self.viewModel = viewModel
+    self._detailUIState = StateObject(wrappedValue: DetailUIState(viewModel: viewModel))
+    self.onShowSidebar = onShowSidebar
+  }
+
   var body: some View {
     Group {
-      switch viewModel.selectedSidebarItem {
+      switch detailUIState.selectedSidebarItem {
       case .cameras:
         // 카메라 상세 화면
-        CameraDetailContentView(viewModel: viewModel)
+        CameraDetailContentView(
+          viewModel: viewModel,
+          currentUIState: detailUIState.currentUIState
+        )
       case .none:
         // 아무것도 선택되지 않은 상태
         VStack {
@@ -53,10 +64,11 @@ struct DetailView: View {
 /// 카메라 상세 콘텐츠 View 컴포넌트
 /// 현재 UI 상태에 따라 적절한 카메라 관련 화면을 표시합니다.
 struct CameraDetailContentView: View {
-  @ObservedObject var viewModel: MainViewModel
+  let viewModel: MainViewModel
+  let currentUIState: UIState
 
   var body: some View {
-    switch viewModel.currentUIState {
+    switch currentUIState {
     case .loading:
       // 로딩 상태
       LoadingView()
@@ -78,19 +90,38 @@ struct CameraDetailContentView: View {
 /// 16:9 비율로 제한하여 실제 송출되는 영역만 표시합니다.
 /// 키보드가 올라와도 레이아웃이 변경되지 않습니다.
 struct CameraPreviewContainerView: View {
-  @ObservedObject var viewModel: MainViewModel
+  @ObservedObject private var cameraViewModel: CameraViewModel
+  @StateObject private var liveStreamUIState: CameraPreviewLiveState
+  @StateObject private var textOverlayUIState: CameraPreviewTextOverlayState
+  @StateObject private var layoutState = CameraPreviewLayoutState()
+  private let liveStreamViewModel: LiveStreamViewModel
+  private let toggleScreenCaptureStreamingAction: () -> Void
+  private let switchToNextCameraAction: () -> Void
+  private let toggleTextOverlayAction: () -> Void
+  private let showTextSettingsAction: () -> Void
   @State private var isAdvancedPanelExpanded = false
 
+  init(viewModel: MainViewModel) {
+    self._cameraViewModel = ObservedObject(wrappedValue: viewModel.cameraViewModel)
+    self.liveStreamViewModel = viewModel.liveStreamViewModel
+    self.toggleScreenCaptureStreamingAction = { viewModel.toggleScreenCaptureStreaming() }
+    self.switchToNextCameraAction = { viewModel.switchToNextCamera() }
+    self.toggleTextOverlayAction = { viewModel.toggleTextOverlay() }
+    self.showTextSettingsAction = { viewModel.showTextSettings() }
+    self._liveStreamUIState = StateObject(
+      wrappedValue: CameraPreviewLiveState(viewModel: viewModel.liveStreamViewModel)
+    )
+    self._textOverlayUIState = StateObject(
+      wrappedValue: CameraPreviewTextOverlayState(viewModel: viewModel)
+    )
+  }
+
   private var isFocusModeActive: Bool {
-    viewModel.liveStreamViewModel.isScreenCaptureStreaming
+    liveStreamUIState.isScreenCaptureStreaming
   }
 
   private var streamLayoutProfile: StreamLayoutProfile {
-    viewModel.liveStreamViewModel.settings.streamLayoutProfile
-  }
-
-  private var isPortraitStream: Bool {
-    viewModel.liveStreamViewModel.settings.streamOrientation.isPortrait
+    liveStreamUIState.settings.streamLayoutProfile
   }
 
   private var shouldShowAdvancedPanels: Bool {
@@ -98,13 +129,13 @@ struct CameraPreviewContainerView: View {
   }
 
   private var isActionLocked: Bool {
-    viewModel.liveStreamViewModel.status == .connecting
-      || viewModel.liveStreamViewModel.status == .disconnecting
-      || viewModel.liveStreamViewModel.isLoading
+    liveStreamUIState.status == .connecting
+      || liveStreamUIState.status == .disconnecting
+      || liveStreamUIState.isLoading
   }
 
   private var selectedCameraTitle: String {
-    viewModel.cameraViewModel.selectedCamera?.name
+    cameraViewModel.selectedCamera?.name
       ?? NSLocalizedString("select_camera", comment: "카메라 선택")
   }
 
@@ -123,27 +154,33 @@ struct CameraPreviewContainerView: View {
   }
 
   private func verticalPreviewHeightRatio(
-    for containerSize: CGSize,
-    showsTextControls: Bool
+    for containerSize: CGSize
   ) -> CGFloat {
-    if isPortraitStream {
-      if isCompactDetailWidth(containerSize) {
-        return showsTextControls ? 0.68 : 0.74
-      }
-      return showsTextControls ? 0.58 : 0.64
-    }
-
     if isCompactDetailWidth(containerSize) {
-      return showsTextControls ? 0.40 : 0.46
+      return 0.66
     }
-    return showsTextControls ? 0.34 : 0.40
+    return 0.58
   }
 
-  private func horizontalPreviewTargetWidthRatio(showsTextControls: Bool) -> CGFloat {
-    if isPortraitStream {
-      return showsTextControls ? 0.50 : 0.56
+  private func horizontalPreviewTargetWidthRatio() -> CGFloat {
+    0.58
+  }
+
+  private func widePreviewHeightRatio() -> CGFloat {
+    switch liveStreamUIState.settings.streamOrientation {
+    case .landscape:
+      return 0.84
+    case .portrait:
+      return 0.84
     }
-    return showsTextControls ? 0.64 : 0.72
+  }
+
+  private func defaultIsWideScreen(for containerSize: CGSize) -> Bool {
+    containerSize.width >= containerSize.height
+  }
+
+  private func defaultShowsSupplementaryInfo(for containerSize: CGSize) -> Bool {
+    shouldShowAdvancedPanels && defaultIsWideScreen(for: containerSize)
   }
 
   var body: some View {
@@ -152,15 +189,49 @@ struct CameraPreviewContainerView: View {
 
       GeometryReader { geometry in
         let containerSize = geometry.size
-        let isWideScreen = containerSize.width >= 980
-          && containerSize.width > containerSize.height * 1.15  // 가로가 긴 화면 판단
+        let fallbackIsWideScreen = defaultIsWideScreen(for: containerSize)
+        let isWideScreen = layoutState.hasResolvedLayout
+          ? layoutState.isWideScreen
+          : fallbackIsWideScreen
+        let showsSupplementaryInfo = layoutState.hasResolvedLayout
+          ? layoutState.showsSupplementaryInfo
+          : defaultShowsSupplementaryInfo(for: containerSize)
 
-        if isWideScreen {
-          // 가로로 긴 화면 (iPad, Mac): 수평 분할
-          horizontalLayout(containerSize: containerSize)
-        } else {
-          // 세로로 긴 화면 (iPhone): 수직 분할
-          verticalLayout(containerSize: containerSize)
+        let rootLayout = isWideScreen
+          ? AnyLayout(HStackLayout(spacing: 8))
+          : AnyLayout(VStackLayout(spacing: 7))
+
+        rootLayout {
+          previewColumn(
+            containerSize: containerSize,
+            isWideScreen: isWideScreen
+          )
+
+          studioSection(
+            containerSize: containerSize,
+            isWideScreen: isWideScreen,
+            showsSupplementaryInfo: showsSupplementaryInfo
+          )
+        }
+        .onAppear {
+          layoutState.scheduleUpdate(
+            for: containerSize,
+            shouldShowAdvancedPanels: shouldShowAdvancedPanels,
+            force: true
+          )
+        }
+        .onChange(of: containerSize) { _, newSize in
+          layoutState.scheduleUpdate(
+            for: newSize,
+            shouldShowAdvancedPanels: shouldShowAdvancedPanels
+          )
+        }
+        .onChange(of: shouldShowAdvancedPanels) { _, newValue in
+          layoutState.scheduleUpdate(
+            for: containerSize,
+            shouldShowAdvancedPanels: newValue,
+            force: true
+          )
         }
       }
     }
@@ -174,7 +245,7 @@ struct CameraPreviewContainerView: View {
       UIApplication.shared.sendAction(
         #selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
     }
-    .onChange(of: viewModel.liveStreamViewModel.status) { oldStatus, newStatus in
+    .onChange(of: liveStreamUIState.status) { oldStatus, newStatus in
       if newStatus == .streaming, oldStatus != .streaming {
         withAnimation(.easeInOut(duration: 0.2)) {
           isAdvancedPanelExpanded = false
@@ -194,20 +265,20 @@ struct CameraPreviewContainerView: View {
     VStack(spacing: 10) {
       HStack(spacing: 10) {
         Button {
-          viewModel.toggleScreenCaptureStreaming()
+          toggleScreenCaptureStreamingAction()
         } label: {
           Label(
-            viewModel.liveStreamViewModel.streamingButtonText,
-            systemImage: viewModel.liveStreamViewModel.isScreenCaptureStreaming
+            liveStreamUIState.streamingButtonText,
+            systemImage: liveStreamUIState.isScreenCaptureStreaming
               ? "stop.fill" : "play.fill"
           )
           .frame(maxWidth: .infinity, minHeight: 50)
         }
-        .buttonStyle(FocusActionButtonStyle(tint: viewModel.liveStreamViewModel.isScreenCaptureStreaming ? .red : .blue))
-        .disabled(isActionLocked || !viewModel.liveStreamViewModel.isScreenCaptureButtonEnabled)
+        .buttonStyle(FocusActionButtonStyle(tint: liveStreamUIState.isScreenCaptureStreaming ? .red : .blue))
+        .disabled(isActionLocked || !liveStreamUIState.isScreenCaptureButtonEnabled)
 
         Button {
-          viewModel.switchToNextCamera()
+          switchToNextCameraAction()
         } label: {
           Label(selectedCameraTitle, systemImage: "arrow.triangle.2.circlepath.camera")
             .lineLimit(1)
@@ -215,40 +286,43 @@ struct CameraPreviewContainerView: View {
             .frame(maxWidth: .infinity, minHeight: 50)
         }
         .buttonStyle(FocusActionButtonStyle(tint: .indigo))
-        .disabled(isActionLocked || !viewModel.canSwitchCameraQuickly)
+        .disabled(
+          isActionLocked
+            || (cameraViewModel.builtInCameras + cameraViewModel.externalCameras).count <= 1
+        )
       }
 
       HStack(spacing: 8) {
         FocusMetricChip(
           title: NSLocalizedString("status", comment: "상태"),
-          value: viewModel.liveStreamViewModel.status.description,
+          value: liveStreamUIState.status.description,
           icon: "dot.radiowaves.left.and.right",
           tint: isFocusModeActive ? .red : .gray
         )
         .frame(maxWidth: .infinity)
 
         Button {
-          viewModel.liveStreamViewModel.toggleMicrophoneMute()
+          liveStreamViewModel.toggleMicrophoneMute()
         } label: {
           Label(
-            viewModel.liveStreamViewModel.isMicrophoneMuted
+            liveStreamUIState.isMicrophoneMuted
               ? NSLocalizedString("microphone_unmute", comment: "마이크 음소거 해제")
               : NSLocalizedString("microphone_mute", comment: "마이크 음소거"),
-            systemImage: viewModel.liveStreamViewModel.isMicrophoneMuted ? "mic.slash.fill" : "mic.fill"
+            systemImage: liveStreamUIState.isMicrophoneMuted ? "mic.slash.fill" : "mic.fill"
           )
           .frame(maxWidth: .infinity, minHeight: 44)
         }
         .buttonStyle(
           FocusActionButtonStyle(
-            tint: viewModel.liveStreamViewModel.isMicrophoneMuted ? .orange : .teal))
+            tint: liveStreamUIState.isMicrophoneMuted ? .orange : .teal))
         .disabled(
-          viewModel.liveStreamViewModel.status == .connecting
-            || viewModel.liveStreamViewModel.status == .disconnecting
+          liveStreamUIState.status == .connecting
+            || liveStreamUIState.status == .disconnecting
         )
 
         FocusMetricChip(
           title: NSLocalizedString("video_bitrate", comment: "비디오 비트레이트"),
-          value: "\(viewModel.liveStreamViewModel.settings.videoBitrate) kbps",
+          value: "\(liveStreamUIState.settings.videoBitrate) kbps",
           icon: "speedometer",
           tint: .blue
         )
@@ -287,63 +361,45 @@ struct CameraPreviewContainerView: View {
   }
 
   @ViewBuilder
-  private func horizontalLayout(containerSize: CGSize) -> some View {
-    let showsTextControls = shouldShowTextControls(for: containerSize, isHorizontal: true)
-    let previewAspect = streamLayoutProfile.aspectRatio
-    let controlsReservedHeight: CGFloat = showsTextControls ? 136 : 0
-    let previewAvailableHeight = max(1, containerSize.height - 40 - controlsReservedHeight)
-    let previewMaxWidthByHeight = previewAvailableHeight * previewAspect
-    let targetLeftWidth = containerSize.width * horizontalPreviewTargetWidthRatio(
-      showsTextControls: showsTextControls
+  private func previewColumn(
+    containerSize: CGSize,
+    isWideScreen: Bool
+  ) -> some View {
+    let showsTextControls = shouldShowTextControls(
+      for: containerSize,
+      isHorizontal: isWideScreen
     )
-    let previewWidth = min(targetLeftWidth, previewMaxWidthByHeight)
-    let leftColumnWidth = previewWidth
-    let columnSpacing: CGFloat = 8
 
-    HStack(spacing: columnSpacing) {
-      // 왼쪽: 카메라 프리뷰 + 텍스트 컨트롤 영역
+    if isWideScreen {
+      let previewAvailableHeight = max(1, containerSize.height * widePreviewHeightRatio())
+      let previewSlotWidth = containerSize.width * horizontalPreviewTargetWidthRatio()
+
       VStack(spacing: 8) {
-        // 카메라 프리뷰
         cameraPreviewSection(
           availableSize: CGSize(
-            width: previewWidth,
+            width: previewSlotWidth,
             height: previewAvailableHeight
           )
         )
 
         if showsTextControls {
-          // 메뉴 접힘 상태에서도 프리뷰를 가리지 않도록 하단에 배치
-          TextOverlayControlView(viewModel: viewModel)
+          TextOverlayControlView(
+            isTextOverlayVisible: textOverlayUIState.showTextOverlay,
+            onToggleTextOverlay: toggleTextOverlayAction,
+            onShowTextSettings: showTextSettingsAction
+          )
             .frame(maxWidth: .infinity, alignment: .trailing)
         }
       }
-      .frame(width: leftColumnWidth, alignment: .leading)
+      .frame(width: previewSlotWidth, alignment: .leading)
       .frame(maxHeight: .infinity, alignment: .topLeading)
+    } else {
+      let previewHeightRatio = verticalPreviewHeightRatio(for: containerSize)
+      let previewAvailableHeight = max(
+        120,
+        containerSize.height * previewHeightRatio
+      )
 
-      // 오른쪽: YouTube Studio 영역 (더 크게)
-      VStack(spacing: 0) {
-        YouTubeStudioAccessView(
-          viewModel: viewModel,
-          showsSupplementaryInfo: shouldShowAdvancedPanels && !isCompactDetailWidth(containerSize)
-        )
-          .frame(maxHeight: .infinity)
-      }
-      .frame(maxWidth: .infinity)
-    }
-  }
-
-  @ViewBuilder
-  private func verticalLayout(containerSize: CGSize) -> some View {
-    let showsTextControls = shouldShowTextControls(for: containerSize, isHorizontal: false)
-    let previewHeightRatio = verticalPreviewHeightRatio(
-      for: containerSize,
-      showsTextControls: showsTextControls
-    )
-    let controlsReservedHeight: CGFloat = showsTextControls ? 136 : 0
-    let previewAvailableHeight = max(120, containerSize.height * previewHeightRatio - controlsReservedHeight)
-
-    VStack(spacing: 7) {  // 간격을 4에서 7픽셀로 조정
-      // 위쪽: 카메라 프리뷰 + 텍스트 컨트롤 영역 (iPhone 포함 하단 배치)
       VStack(alignment: .trailing, spacing: 8) {
         cameraPreviewSection(
           availableSize: CGSize(
@@ -353,33 +409,41 @@ struct CameraPreviewContainerView: View {
         )
 
         if showsTextControls {
-          TextOverlayControlView(viewModel: viewModel)
+          TextOverlayControlView(
+            isTextOverlayVisible: textOverlayUIState.showTextOverlay,
+            onToggleTextOverlay: toggleTextOverlayAction,
+            onShowTextSettings: showTextSettingsAction
+          )
             .frame(maxWidth: .infinity, alignment: .trailing)
         }
       }
-      .layoutPriority(0)  // 낮은 우선순위로 설정
-
-      // 아래쪽: YouTube Studio 영역 (남은 공간 모두 차지)
-      YouTubeStudioAccessView(
-        viewModel: viewModel,
-        showsSupplementaryInfo: shouldShowAdvancedPanels && !isCompactDetailWidth(containerSize)
-      )
-        .frame(maxWidth: .infinity, maxHeight: .infinity)  // 남은 공간 모두 차지
-        .layoutPriority(1)  // 높은 우선순위로 확장
+      .layoutPriority(0)
     }
   }
 
   @ViewBuilder
+  private func studioSection(
+    containerSize: CGSize,
+    isWideScreen: Bool,
+    showsSupplementaryInfo: Bool
+  ) -> some View {
+    YouTubeStudioAccessView(
+      streamingStatusDescription: liveStreamUIState.status.description,
+      isStreaming: liveStreamUIState.status == .streaming,
+      isValidStreamKey: liveStreamUIState.isValidStreamKey,
+      showsSupplementaryInfo: showsSupplementaryInfo
+    )
+    .frame(maxWidth: .infinity, maxHeight: .infinity)
+    .layoutPriority(isWideScreen ? 0 : 1)
+  }
+
+  @ViewBuilder
   private func cameraPreviewSection(availableSize: CGSize) -> some View {
-    let liveStreamSettings = viewModel.liveStreamViewModel.settings
+    let liveStreamSettings = liveStreamUIState.settings
     let aspectRatio = streamLayoutProfile.aspectRatio
     let audioMeterHeight: CGFloat = 40
     let maxWidth = availableSize.width
     let maxHeight = max(120, availableSize.height - audioMeterHeight)  // 하단 오디오 피크 영역 확보
-    let previewIdentity = [
-      liveStreamSettings.streamOrientation.rawValue,
-      "\(liveStreamSettings.videoWidth)x\(liveStreamSettings.videoHeight)"
-    ].joined(separator: "|")
 
     // Aspect Fit 방식으로 16:9 프레임 계산
     let previewSize: CGSize = {
@@ -398,14 +462,13 @@ struct CameraPreviewContainerView: View {
       ZStack {
         // 카메라 프리뷰
         CameraPreviewView(
-          session: viewModel.cameraViewModel.captureSession,
-          cameraViewModel: viewModel.cameraViewModel,
+          session: cameraViewModel.captureSession,
+          cameraViewModel: cameraViewModel,
           streamingSettings: liveStreamSettings,
-          haishinKitManager: viewModel.liveStreamViewModel.streamingService as? HaishinKitManager,
-          showTextOverlay: viewModel.showTextOverlay,
-          overlayText: viewModel.currentOverlayText
+          haishinKitManager: liveStreamViewModel.streamingService as? HaishinKitManager,
+          showTextOverlay: textOverlayUIState.showTextOverlay,
+          overlayText: textOverlayUIState.currentOverlayText
         )
-        .id(previewIdentity)
         .aspectRatio(aspectRatio, contentMode: .fit)
         .frame(width: previewSize.width, height: previewSize.height)
         .background(Color.black)
@@ -416,36 +479,42 @@ struct CameraPreviewContainerView: View {
         )
         .onAppear {
           // HaishinKitManager에 텍스트 오버레이 정보 전달
-          if let haishinKitManager = viewModel.liveStreamViewModel.streamingService
+          if let haishinKitManager = liveStreamViewModel.streamingService
             as? HaishinKitManager
           {
             haishinKitManager.updateTextOverlay(
-              show: viewModel.showTextOverlay, settings: viewModel.textOverlaySettings)
+              show: textOverlayUIState.showTextOverlay,
+              settings: textOverlayUIState.settings
+            )
           }
         }
-        .onChange(of: viewModel.textOverlaySettings) { _, newSettings in
+        .onChange(of: textOverlayUIState.settings) { _, newSettings in
           // 텍스트 설정 변경 시 HaishinKitManager 업데이트
-          if let haishinKitManager = viewModel.liveStreamViewModel.streamingService
+          if let haishinKitManager = liveStreamViewModel.streamingService
             as? HaishinKitManager
           {
             haishinKitManager.updateTextOverlay(
-              show: viewModel.showTextOverlay, settings: newSettings)
+              show: textOverlayUIState.showTextOverlay,
+              settings: newSettings
+            )
           }
         }
-        .onChange(of: viewModel.showTextOverlay) { _, newValue in
+        .onChange(of: textOverlayUIState.showTextOverlay) { _, newValue in
           // 텍스트 표시 상태 변경 시 HaishinKitManager 업데이트
-          if let haishinKitManager = viewModel.liveStreamViewModel.streamingService
+          if let haishinKitManager = liveStreamViewModel.streamingService
             as? HaishinKitManager
           {
             haishinKitManager.updateTextOverlay(
-              show: newValue, settings: viewModel.textOverlaySettings)
+              show: newValue,
+              settings: textOverlayUIState.settings
+            )
           }
         }
 
         // 텍스트 오버레이
-        if viewModel.showTextOverlay {
+        if textOverlayUIState.showTextOverlay {
           TextOverlayDisplayView(
-            settings: viewModel.textOverlaySettings,
+            settings: textOverlayUIState.settings,
             previewSize: previewSize
           )
         }
@@ -458,17 +527,299 @@ struct CameraPreviewContainerView: View {
       }
 
       AudioPeakMeterView(
-        level: viewModel.liveStreamViewModel.microphonePeakLevel,
-        decibels: viewModel.liveStreamViewModel.microphonePeakDecibels,
-        isMuted: viewModel.liveStreamViewModel.isMicrophoneMuted,
-        isStreaming: viewModel.liveStreamViewModel.status == .streaming,
-        diagnosticMessage: viewModel.liveStreamViewModel.audioPeakDiagnosticMessage,
-        inputSummary: viewModel.liveStreamViewModel.activeMicrophoneDisplaySummary
+        viewModel: liveStreamViewModel
       )
       .frame(width: previewSize.width)
     }
+    .frame(width: availableSize.width, height: availableSize.height, alignment: .top)
   }
 
+}
+
+@MainActor
+private final class CameraPreviewLiveState: ObservableObject {
+  @Published private var snapshot: CameraPreviewLiveSnapshot
+
+  private let viewModel: LiveStreamViewModel
+  private var cancellables = Set<AnyCancellable>()
+
+  init(viewModel: LiveStreamViewModel) {
+    self.viewModel = viewModel
+    self.snapshot = CameraPreviewLiveSnapshot(
+      settings: viewModel.settings,
+      status: viewModel.status,
+      isLoading: viewModel.isLoading,
+      isMicrophoneMuted: viewModel.isMicrophoneMuted,
+      isScreenCaptureStreaming: viewModel.isScreenCaptureStreaming,
+      streamingButtonText: viewModel.streamingButtonText,
+      isScreenCaptureButtonEnabled: viewModel.isScreenCaptureButtonEnabled,
+      isValidStreamKey: Self.makeIsValidStreamKey(from: viewModel.settings)
+    )
+
+    bind()
+  }
+
+  var settings: LiveStreamSettings { snapshot.settings }
+  var status: LiveStreamStatus { snapshot.status }
+  var isLoading: Bool { snapshot.isLoading }
+  var isMicrophoneMuted: Bool { snapshot.isMicrophoneMuted }
+  var isScreenCaptureStreaming: Bool { snapshot.isScreenCaptureStreaming }
+  var streamingButtonText: String { snapshot.streamingButtonText }
+  var isScreenCaptureButtonEnabled: Bool { snapshot.isScreenCaptureButtonEnabled }
+  var isValidStreamKey: Bool { snapshot.isValidStreamKey }
+
+  private func bind() {
+    viewModel.$settings
+      .removeDuplicates(by: { lhs, rhs in
+        lhs.videoWidth == rhs.videoWidth
+          && lhs.videoHeight == rhs.videoHeight
+          && lhs.videoBitrate == rhs.videoBitrate
+          && lhs.frameRate == rhs.frameRate
+          && lhs.streamOrientation == rhs.streamOrientation
+          && lhs.streamKey == rhs.streamKey
+      })
+      .sink { [weak self] settings in
+        self?.updateSnapshot { snapshot in
+          snapshot.settings = settings
+          snapshot.isValidStreamKey = Self.makeIsValidStreamKey(from: settings)
+          Self.applyDerivedStreamingState(from: self?.viewModel, to: &snapshot)
+        }
+      }
+      .store(in: &cancellables)
+
+    viewModel.$status
+      .removeDuplicates()
+      .sink { [weak self] status in
+        self?.updateSnapshot { snapshot in
+          snapshot.status = status
+          Self.applyDerivedStreamingState(from: self?.viewModel, to: &snapshot)
+        }
+      }
+      .store(in: &cancellables)
+
+    viewModel.$isLoading
+      .removeDuplicates()
+      .sink { [weak self] isLoading in
+        self?.updateSnapshot { snapshot in
+          snapshot.isLoading = isLoading
+          Self.applyDerivedStreamingState(from: self?.viewModel, to: &snapshot)
+        }
+      }
+      .store(in: &cancellables)
+
+    viewModel.$isMicrophoneMuted
+      .removeDuplicates()
+      .sink { [weak self] isMuted in
+        self?.updateSnapshot { snapshot in
+          snapshot.isMicrophoneMuted = isMuted
+        }
+      }
+      .store(in: &cancellables)
+
+    viewModel.$canStartStreaming
+      .removeDuplicates()
+      .sink { [weak self] _ in
+        self?.updateSnapshot { snapshot in
+          Self.applyDerivedStreamingState(from: self?.viewModel, to: &snapshot)
+        }
+      }
+      .store(in: &cancellables)
+  }
+
+  private func updateSnapshot(_ mutate: (inout CameraPreviewLiveSnapshot) -> Void) {
+    var updatedSnapshot = snapshot
+    mutate(&updatedSnapshot)
+    guard updatedSnapshot != snapshot else { return }
+    snapshot = updatedSnapshot
+  }
+
+  private static func applyDerivedStreamingState(
+    from viewModel: LiveStreamViewModel?,
+    to snapshot: inout CameraPreviewLiveSnapshot
+  ) {
+    guard let viewModel else { return }
+    snapshot.isScreenCaptureStreaming = viewModel.isScreenCaptureStreaming
+    snapshot.streamingButtonText = viewModel.streamingButtonText
+    snapshot.isScreenCaptureButtonEnabled = viewModel.isScreenCaptureButtonEnabled
+  }
+
+  private static func makeIsValidStreamKey(from settings: LiveStreamSettings) -> Bool {
+    !settings.streamKey.isEmpty && settings.streamKey != "YOUR_YOUTUBE_STREAM_KEY_HERE"
+  }
+}
+
+@MainActor
+private final class CameraPreviewTextOverlayState: ObservableObject {
+  @Published private var snapshot: CameraPreviewTextOverlaySnapshot
+
+  private var cancellables = Set<AnyCancellable>()
+
+  init(viewModel: MainViewModel) {
+    self.snapshot = CameraPreviewTextOverlaySnapshot(
+      showTextOverlay: viewModel.showTextOverlay,
+      settings: viewModel.textOverlaySettings
+    )
+
+    viewModel.$showTextOverlay
+      .combineLatest(viewModel.$textOverlaySettings)
+      .map { showTextOverlay, settings in
+        CameraPreviewTextOverlaySnapshot(
+          showTextOverlay: showTextOverlay,
+          settings: settings
+        )
+      }
+      .removeDuplicates()
+      .sink { [weak self] snapshot in
+        self?.snapshot = snapshot
+      }
+      .store(in: &cancellables)
+  }
+
+  var showTextOverlay: Bool { snapshot.showTextOverlay }
+  var settings: TextOverlaySettings { snapshot.settings }
+  var currentOverlayText: String { snapshot.settings.text }
+}
+
+@MainActor
+private final class DetailUIState: ObservableObject {
+  @Published private(set) var selectedSidebarItem: SidebarItem?
+  @Published private(set) var currentUIState: UIState
+
+  private var cancellables = Set<AnyCancellable>()
+
+  init(viewModel: MainViewModel) {
+    self.selectedSidebarItem = viewModel.selectedSidebarItem
+    self.currentUIState = viewModel.currentUIState
+
+    viewModel.$selectedSidebarItem
+      .removeDuplicates()
+      .sink { [weak self] selectedSidebarItem in
+        self?.selectedSidebarItem = selectedSidebarItem
+      }
+      .store(in: &cancellables)
+
+    viewModel.$currentUIState
+      .removeDuplicates()
+      .sink { [weak self] currentUIState in
+        self?.currentUIState = currentUIState
+      }
+      .store(in: &cancellables)
+  }
+}
+
+private struct CameraPreviewLiveSnapshot: Equatable {
+  var settings: LiveStreamSettings
+  var status: LiveStreamStatus
+  var isLoading: Bool
+  var isMicrophoneMuted: Bool
+  var isScreenCaptureStreaming: Bool
+  var streamingButtonText: String
+  var isScreenCaptureButtonEnabled: Bool
+  var isValidStreamKey: Bool
+
+  static func == (lhs: CameraPreviewLiveSnapshot, rhs: CameraPreviewLiveSnapshot) -> Bool {
+    lhs.status == rhs.status
+      && lhs.isLoading == rhs.isLoading
+      && lhs.isMicrophoneMuted == rhs.isMicrophoneMuted
+      && lhs.isScreenCaptureStreaming == rhs.isScreenCaptureStreaming
+      && lhs.streamingButtonText == rhs.streamingButtonText
+      && lhs.isScreenCaptureButtonEnabled == rhs.isScreenCaptureButtonEnabled
+      && lhs.isValidStreamKey == rhs.isValidStreamKey
+      && lhs.settings.videoWidth == rhs.settings.videoWidth
+      && lhs.settings.videoHeight == rhs.settings.videoHeight
+      && lhs.settings.videoBitrate == rhs.settings.videoBitrate
+      && lhs.settings.frameRate == rhs.settings.frameRate
+      && lhs.settings.streamOrientation == rhs.settings.streamOrientation
+      && lhs.settings.streamKey == rhs.settings.streamKey
+  }
+}
+
+private struct CameraPreviewTextOverlaySnapshot: Equatable {
+  var showTextOverlay: Bool
+  var settings: TextOverlaySettings
+}
+
+@MainActor
+private final class CameraPreviewLayoutState: ObservableObject {
+  @Published private(set) var hasResolvedLayout = false
+  @Published private(set) var isWideScreen = false
+  @Published private(set) var showsSupplementaryInfo = true
+
+  private var pendingUpdate: DispatchWorkItem?
+  private let debounceInterval: TimeInterval = 0.04
+
+  deinit {
+    pendingUpdate?.cancel()
+  }
+
+  func scheduleUpdate(
+    for containerSize: CGSize,
+    shouldShowAdvancedPanels: Bool,
+    force: Bool = false
+  ) {
+    pendingUpdate?.cancel()
+
+    let workItem = DispatchWorkItem { [weak self] in
+      self?.applyResolvedLayout(
+        for: containerSize,
+        shouldShowAdvancedPanels: shouldShowAdvancedPanels
+      )
+    }
+
+    pendingUpdate = workItem
+    let delay = force ? 0 : debounceInterval
+    DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: workItem)
+  }
+
+  private func applyResolvedLayout(
+    for containerSize: CGSize,
+    shouldShowAdvancedPanels: Bool
+  ) {
+    let resolvedIsWideScreen = makeResolvedWideScreenValue(for: containerSize)
+    let resolvedShowsSupplementaryInfo = shouldShowAdvancedPanels && resolvedIsWideScreen
+
+    let layoutChanged =
+      !hasResolvedLayout
+      || isWideScreen != resolvedIsWideScreen
+      || showsSupplementaryInfo != resolvedShowsSupplementaryInfo
+
+    hasResolvedLayout = true
+    guard layoutChanged else { return }
+
+    isWideScreen = resolvedIsWideScreen
+    showsSupplementaryInfo = resolvedShowsSupplementaryInfo
+  }
+
+  private func makeResolvedWideScreenValue(for containerSize: CGSize) -> Bool {
+    let aspectRatio = containerSize.width / max(containerSize.height, 1)
+    let aspectThreshold: CGFloat = 1.0
+    let aspectHysteresis: CGFloat = 0.04
+
+    if !hasResolvedLayout {
+      return aspectRatio >= aspectThreshold
+    }
+
+    if isWideScreen {
+      return aspectRatio >= (aspectThreshold - aspectHysteresis)
+    }
+
+    return aspectRatio >= (aspectThreshold + aspectHysteresis)
+  }
+}
+
+private struct AudioPeakMeterView: View {
+  @ObservedObject var viewModel: LiveStreamViewModel
+
+  var body: some View {
+    AudioPeakMeterContentView(
+      level: viewModel.microphonePeakLevel,
+      decibels: viewModel.microphonePeakDecibels,
+      isMuted: viewModel.isMicrophoneMuted,
+      isStreaming: viewModel.status == .streaming,
+      diagnosticMessage: viewModel.audioPeakDiagnosticMessage,
+      inputSummary: viewModel.activeMicrophoneDisplaySummary
+    )
+  }
 }
 
 private struct FocusActionButtonStyle: ButtonStyle {

--- a/USBExternalCamera/Views/Common/DetailView.swift
+++ b/USBExternalCamera/Views/Common/DetailView.swift
@@ -85,6 +85,14 @@ struct CameraPreviewContainerView: View {
     viewModel.liveStreamViewModel.isScreenCaptureStreaming
   }
 
+  private var streamLayoutProfile: StreamLayoutProfile {
+    viewModel.liveStreamViewModel.settings.streamLayoutProfile
+  }
+
+  private var isPortraitStream: Bool {
+    viewModel.liveStreamViewModel.settings.streamOrientation.isPortrait
+  }
+
   private var shouldShowAdvancedPanels: Bool {
     !isFocusModeActive || isAdvancedPanelExpanded
   }
@@ -118,10 +126,24 @@ struct CameraPreviewContainerView: View {
     for containerSize: CGSize,
     showsTextControls: Bool
   ) -> CGFloat {
+    if isPortraitStream {
+      if isCompactDetailWidth(containerSize) {
+        return showsTextControls ? 0.68 : 0.74
+      }
+      return showsTextControls ? 0.58 : 0.64
+    }
+
     if isCompactDetailWidth(containerSize) {
       return showsTextControls ? 0.40 : 0.46
     }
     return showsTextControls ? 0.34 : 0.40
+  }
+
+  private func horizontalPreviewTargetWidthRatio(showsTextControls: Bool) -> CGFloat {
+    if isPortraitStream {
+      return showsTextControls ? 0.50 : 0.56
+    }
+    return showsTextControls ? 0.64 : 0.72
   }
 
   var body: some View {
@@ -267,11 +289,13 @@ struct CameraPreviewContainerView: View {
   @ViewBuilder
   private func horizontalLayout(containerSize: CGSize) -> some View {
     let showsTextControls = shouldShowTextControls(for: containerSize, isHorizontal: true)
-    let previewAspect: CGFloat = 16.0 / 9.0
+    let previewAspect = streamLayoutProfile.aspectRatio
     let controlsReservedHeight: CGFloat = showsTextControls ? 136 : 0
     let previewAvailableHeight = max(1, containerSize.height - 40 - controlsReservedHeight)
     let previewMaxWidthByHeight = previewAvailableHeight * previewAspect
-    let targetLeftWidth = showsTextControls ? containerSize.width * 0.64 : containerSize.width * 0.72
+    let targetLeftWidth = containerSize.width * horizontalPreviewTargetWidthRatio(
+      showsTextControls: showsTextControls
+    )
     let previewWidth = min(targetLeftWidth, previewMaxWidthByHeight)
     let leftColumnWidth = previewWidth
     let columnSpacing: CGFloat = 8
@@ -347,11 +371,15 @@ struct CameraPreviewContainerView: View {
 
   @ViewBuilder
   private func cameraPreviewSection(availableSize: CGSize) -> some View {
-    // 16:9 비율 계산 (유튜브 라이브 표준)
-    let aspectRatio: CGFloat = 16.0 / 9.0
+    let liveStreamSettings = viewModel.liveStreamViewModel.settings
+    let aspectRatio = streamLayoutProfile.aspectRatio
     let audioMeterHeight: CGFloat = 40
     let maxWidth = availableSize.width
     let maxHeight = max(120, availableSize.height - audioMeterHeight)  // 하단 오디오 피크 영역 확보
+    let previewIdentity = [
+      liveStreamSettings.streamOrientation.rawValue,
+      "\(liveStreamSettings.videoWidth)x\(liveStreamSettings.videoHeight)"
+    ].joined(separator: "|")
 
     // Aspect Fit 방식으로 16:9 프레임 계산
     let previewSize: CGSize = {
@@ -365,7 +393,6 @@ struct CameraPreviewContainerView: View {
         return CGSize(width: maxWidth, height: height)
       }
     }()
-
     VStack(spacing: 6) {
       // 16:9 프리뷰 영역 (프리뷰 정보 텍스트 제거하여 간격 최소화)
       ZStack {
@@ -373,11 +400,12 @@ struct CameraPreviewContainerView: View {
         CameraPreviewView(
           session: viewModel.cameraViewModel.captureSession,
           cameraViewModel: viewModel.cameraViewModel,
-          streamViewModel: viewModel.liveStreamViewModel,
+          streamingSettings: liveStreamSettings,
           haishinKitManager: viewModel.liveStreamViewModel.streamingService as? HaishinKitManager,
           showTextOverlay: viewModel.showTextOverlay,
           overlayText: viewModel.currentOverlayText
         )
+        .id(previewIdentity)
         .aspectRatio(aspectRatio, contentMode: .fit)
         .frame(width: previewSize.width, height: previewSize.height)
         .background(Color.black)

--- a/USBExternalCamera/Views/Common/SidebarView.swift
+++ b/USBExternalCamera/Views/Common/SidebarView.swift
@@ -16,13 +16,16 @@ struct SidebarView: View {
     /// MainViewModel 참조 (ObservedObject로 상태 변화 감지)
     @ObservedObject var viewModel: MainViewModel
     let onPrimarySelection: () -> Void
+    let onShowLiveStreamSettings: () -> Void
 
     init(
         viewModel: MainViewModel,
-        onPrimarySelection: @escaping () -> Void = {}
+        onPrimarySelection: @escaping () -> Void = {},
+        onShowLiveStreamSettings: @escaping () -> Void = {}
     ) {
         self.viewModel = viewModel
         self.onPrimarySelection = onPrimarySelection
+        self.onShowLiveStreamSettings = onShowLiveStreamSettings
     }
     
     var body: some View {
@@ -36,7 +39,7 @@ struct SidebarView: View {
             // 라이브 스트리밍 섹션: 라이브 스트리밍 관련 메뉴
             LiveStreamSectionView(
                 viewModel: viewModel.liveStreamViewModel,
-                onShowSettings: { viewModel.showLiveStreamSettings() }
+                onShowSettings: onShowLiveStreamSettings
             )
         }
         .navigationTitle(NSLocalizedString("menu", comment: "메뉴"))

--- a/USBExternalCamera/Views/Common/YouTubeStudioAccessView.swift
+++ b/USBExternalCamera/Views/Common/YouTubeStudioAccessView.swift
@@ -26,7 +26,9 @@ import WebKit
 /// - 웹사이트 데이터 지속성 (로그인 상태 유지)
 /// - iOS 버전별 최신 웹 기능 활성화
 struct YouTubeStudioAccessView: View {
-    @ObservedObject var viewModel: MainViewModel
+    let streamingStatusDescription: String
+    let isStreaming: Bool
+    let isValidStreamKey: Bool
     var showsSupplementaryInfo: Bool = true
     @StateObject private var keyboardAccessoryManager = KeyboardAccessoryManager()
     
@@ -93,9 +95,6 @@ struct YouTubeStudioAccessView: View {
     
     @ViewBuilder
     private var streamingStatusCard: some View {
-        let streamingStatus = viewModel.liveStreamViewModel.status
-        let isStreaming = (streamingStatus == .streaming)
-        
         HStack {
             // 라이브 상태 표시
             Circle()
@@ -111,7 +110,7 @@ struct YouTubeStudioAccessView: View {
                     .fontWeight(.bold)
                     .foregroundColor(isStreaming ? .red : .secondary)
                 
-                Text(streamingStatus.description)
+                Text(streamingStatusDescription)
                     .font(.caption2)
                     .foregroundColor(.secondary)
             }
@@ -129,9 +128,6 @@ struct YouTubeStudioAccessView: View {
     
     @ViewBuilder
     private var streamKeyStatusIndicator: some View {
-        let hasStreamKey = !viewModel.liveStreamViewModel.settings.streamKey.isEmpty
-        let isValidStreamKey = viewModel.liveStreamViewModel.settings.streamKey != "YOUR_YOUTUBE_STREAM_KEY_HERE" && hasStreamKey
-        
         Image(systemName: isValidStreamKey ? "key.fill" : "key.slash")
             .foregroundColor(isValidStreamKey ? .green : .red)
             .font(.caption)

--- a/USBExternalCamera/Views/LiveStream/AudioPeakMeterView.swift
+++ b/USBExternalCamera/Views/LiveStream/AudioPeakMeterView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 /// 카메라 프리뷰 하단에 표시되는 실시간 마이크 피크 미터
-struct AudioPeakMeterView: View {
+struct AudioPeakMeterContentView: View {
   let level: Float
   let decibels: Float
   let isMuted: Bool
@@ -50,6 +50,14 @@ struct AudioPeakMeterView: View {
     )
   }
 
+  private var visibleBarScale: CGFloat {
+    guard !isMuted else { return 0 }
+    if clampedLevel > 0.01 {
+      return max(clampedLevel, 0.015)
+    }
+    return 0
+  }
+
   var body: some View {
     VStack(spacing: 4) {
       HStack(spacing: 6) {
@@ -84,24 +92,19 @@ struct AudioPeakMeterView: View {
         .lineLimit(1)
         .minimumScaleFactor(0.85)
 
-      GeometryReader { geometry in
-        let rawWidth = geometry.size.width * (isMuted ? 0 : clampedLevel)
-        let barWidth = max(rawWidth, (!isMuted && clampedLevel > 0.01) ? 3 : 0)
+      ZStack(alignment: .leading) {
+        Capsule()
+          .fill(Color.secondary.opacity(0.2))
 
-        ZStack(alignment: .leading) {
-          Capsule()
-            .fill(Color.secondary.opacity(0.2))
-
-          Capsule()
-            .fill(
-              isMuted
-                ? AnyShapeStyle(mutedTint)
-                : AnyShapeStyle(activeTint)
-            )
-            .frame(width: barWidth)
-            .animation(.easeOut(duration: 0.1), value: clampedLevel)
-            .animation(.easeInOut(duration: 0.2), value: isMuted)
-        }
+        Capsule()
+          .fill(
+            isMuted
+              ? AnyShapeStyle(mutedTint)
+              : AnyShapeStyle(activeTint)
+          )
+          .scaleEffect(x: visibleBarScale, y: 1, anchor: .leading)
+          .animation(.easeOut(duration: 0.1), value: clampedLevel)
+          .animation(.easeInOut(duration: 0.2), value: isMuted)
       }
       .frame(height: 7)
 

--- a/USBExternalCamera/Views/LiveStream/AudioSettingsSectionView.swift
+++ b/USBExternalCamera/Views/LiveStream/AudioSettingsSectionView.swift
@@ -102,7 +102,11 @@ struct AudioSettingsSectionView: View {
 
                     Slider(value: Binding(
                         get: { Double(viewModel.settings.audioBitrate) },
-                        set: { viewModel.settings.audioBitrate = Int($0) }
+                        set: { newValue in
+                            viewModel.updateSettings { settings in
+                                settings.audioBitrate = Int(newValue)
+                            }
+                        }
                     ), in: 64...320, step: 32)
 
                     // 권장 비트레이트 가이드

--- a/USBExternalCamera/Views/LiveStream/LiveStreamSettingsSupportingViews.swift
+++ b/USBExternalCamera/Views/LiveStream/LiveStreamSettingsSupportingViews.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import LiveStreamingCore
 
 // MARK: - Supporting Views
 
@@ -34,6 +35,29 @@ struct StatusSectionView: View {
 /// 기본 설정 섹션
 struct BasicSettingsSectionView: View {
     @ObservedObject var viewModel: LiveStreamViewModel
+
+    private var rtmpURLBinding: Binding<String> {
+        Binding(
+            get: { viewModel.settings.rtmpURL },
+            set: { newValue in
+                viewModel.updateSettings { settings in
+                    settings.rtmpURL = newValue
+                }
+            }
+        )
+    }
+
+    private var streamKeyBinding: Binding<String> {
+        Binding(
+            get: { viewModel.settings.streamKey },
+            set: { newValue in
+                let cleaned = cleanStreamKey(newValue)
+                viewModel.updateSettings { settings in
+                    settings.streamKey = cleaned
+                }
+            }
+        )
+    }
     
     var body: some View {
         SettingsSectionView(title: NSLocalizedString("basic_settings", comment: ""), icon: "gear") {
@@ -44,7 +68,7 @@ struct BasicSettingsSectionView: View {
                 VStack(alignment: .leading, spacing: 8) {
                     Text(NSLocalizedString("rtmp_url", comment: ""))
                         .font(.headline)
-                    TextField(NSLocalizedString("rtmp_url_placeholder", comment: ""), text: $viewModel.settings.rtmpURL)
+                    TextField(NSLocalizedString("rtmp_url_placeholder", comment: ""), text: rtmpURLBinding)
                         .textFieldStyle(RoundedBorderTextFieldStyle())
                 }
                 
@@ -57,15 +81,8 @@ struct BasicSettingsSectionView: View {
                         // 스트림 키 검증 상태 표시
                         streamKeyValidationIcon
                     }
-                    SecureField(NSLocalizedString("stream_key_placeholder", comment: ""), text: $viewModel.settings.streamKey)
+                    SecureField(NSLocalizedString("stream_key_placeholder", comment: ""), text: streamKeyBinding)
                         .textFieldStyle(RoundedBorderTextFieldStyle())
-                        .onChange(of: viewModel.settings.streamKey) { oldValue, newValue in
-                            // 실시간 스트림 키 정제
-                            let cleaned = cleanStreamKey(newValue)
-                            if cleaned != newValue {
-                                viewModel.settings.streamKey = cleaned
-                            }
-                        }
                     
                     // 스트림 키 상태 메시지
                     if !viewModel.settings.streamKey.isEmpty {
@@ -153,76 +170,85 @@ struct BasicSettingsSectionView: View {
 struct VideoSettingsSectionView: View {
     @ObservedObject var viewModel: LiveStreamViewModel
 
-    enum Resolution {
-        case resolution480p
-        case resolution720p
-        case resolution1080p
+    private var currentResolutionClass: StreamResolutionClass {
+        viewModel.settings.normalizedResolutionClass
     }
 
-    var currentResolution: Resolution {
-        let width = viewModel.settings.videoWidth
-        let height = viewModel.settings.videoHeight
-
-        if width == 848 && height == 480 {
-            return .resolution480p
-        } else if width == 1280 && height == 720 {
-            return .resolution720p
-        } else if width == 1920 && height == 1080 {
-            return .resolution1080p
+    private var isOrientationLocked: Bool {
+        switch viewModel.status {
+        case .connected, .streaming, .connecting, .disconnecting:
+            return true
+        case .idle, .error:
+            return false
         }
-        return .resolution1080p
     }
 
-    func setResolution(_ resolution: Resolution) {
-        switch resolution {
-        case .resolution480p:
-            viewModel.settings.videoWidth = 848
-            viewModel.settings.videoHeight = 480
-        case .resolution720p:
-            viewModel.settings.videoWidth = 1280
-            viewModel.settings.videoHeight = 720
-        case .resolution1080p:
-            viewModel.settings.videoWidth = 1920
-            viewModel.settings.videoHeight = 1080
+    private func resolutionSubtitle(for resolutionClass: StreamResolutionClass) -> String {
+        guard let size = StreamResolutionDescriptor.presetSize(
+            for: resolutionClass,
+            orientation: viewModel.settings.streamOrientation
+        ) else {
+            return "\(viewModel.settings.videoWidth)×\(viewModel.settings.videoHeight)"
         }
-        normalizeFrameRateIfNeeded(for: resolution)
-        viewModel.settings.videoBitrate = YouTubeBitrateAdvisor.recommendedH264Bitrate(
-            width: viewModel.settings.videoWidth,
-            height: viewModel.settings.videoHeight,
-            frameRate: viewModel.settings.frameRate
-        )
+        return "\(size.width)×\(size.height)"
     }
 
-    private func supportedFrameRates(for resolution: Resolution) -> [Int] {
-        switch resolution {
-        case .resolution480p:
-            return [24, 30]
-        case .resolution720p:
+    private func setResolution(_ resolutionClass: StreamResolutionClass) {
+        guard !isOrientationLocked else { return }
+        viewModel.updateSettings { settings in
+            settings.applyResolutionClass(resolutionClass)
+
+            let supportedRates = supportedFrameRates(for: resolutionClass)
+            if !supportedRates.contains(settings.frameRate) {
+                settings.frameRate = supportedRates.contains(30) ? 30 : supportedRates.last ?? 30
+            }
+
+            settings.videoBitrate = YouTubeBitrateAdvisor.recommendedH264Bitrate(
+                width: settings.videoWidth,
+                height: settings.videoHeight,
+                frameRate: settings.frameRate
+            )
+        }
+    }
+
+    private func supportedFrameRates(for resolutionClass: StreamResolutionClass) -> [Int] {
+        switch resolutionClass {
+        case .p720:
             return [24, 30, 60]
-        case .resolution1080p:
+        case .p480, .p1080, .p4k, .custom:
             return [24, 30]
         }
     }
 
-    private func normalizeFrameRateIfNeeded(for resolution: Resolution) {
-        let supportedRates = supportedFrameRates(for: resolution)
+    private func normalizeFrameRateIfNeeded(for resolutionClass: StreamResolutionClass) {
+        let supportedRates = supportedFrameRates(for: resolutionClass)
         guard !supportedRates.contains(viewModel.settings.frameRate) else { return }
-        viewModel.settings.frameRate = supportedRates.contains(30) ? 30 : supportedRates.last ?? 30
+        viewModel.updateSettings { settings in
+            settings.frameRate = supportedRates.contains(30) ? 30 : supportedRates.last ?? 30
+        }
     }
 
     private func setFrameRate(_ frameRate: Int) {
         guard isFrameRateSupported(frameRate) else { return }
-        viewModel.settings.frameRate = frameRate
-        viewModel.settings.videoBitrate = YouTubeBitrateAdvisor.recommendedH264Bitrate(
-            width: viewModel.settings.videoWidth,
-            height: viewModel.settings.videoHeight,
-            frameRate: viewModel.settings.frameRate
-        )
+        viewModel.updateSettings { settings in
+            settings.frameRate = frameRate
+            settings.videoBitrate = YouTubeBitrateAdvisor.recommendedH264Bitrate(
+                width: settings.videoWidth,
+                height: settings.videoHeight,
+                frameRate: settings.frameRate
+            )
+        }
+    }
+
+    private func updateOrientation(_ orientation: StreamOrientation) {
+        guard !isOrientationLocked else { return }
+        viewModel.updateStreamOrientation(orientation)
+        normalizeFrameRateIfNeeded(for: currentResolutionClass)
     }
 
     /// 프레임레이트 지원 여부 확인
     func isFrameRateSupported(_ frameRate: Int) -> Bool {
-        supportedFrameRates(for: currentResolution).contains(frameRate)
+        supportedFrameRates(for: currentResolutionClass).contains(frameRate)
     }
 
     var bitrateColor: Color {
@@ -309,6 +335,37 @@ struct VideoSettingsSectionView: View {
     var body: some View {
         SettingsSectionView(title: NSLocalizedString("video_settings", comment: ""), icon: "video") {
             VStack(spacing: 16) {
+                VStack(alignment: .leading, spacing: 8) {
+                    HStack {
+                        Text(NSLocalizedString("stream_orientation", comment: "송출 방향"))
+                            .font(.subheadline)
+                            .fontWeight(.medium)
+                        Spacer()
+                        Text("\(viewModel.settings.videoWidth)×\(viewModel.settings.videoHeight)")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    }
+
+                    Picker(
+                        NSLocalizedString("stream_orientation", comment: "송출 방향"),
+                        selection: Binding(
+                            get: { viewModel.settings.streamOrientation },
+                            set: { updateOrientation($0) }
+                        )
+                    ) {
+                        Text(NSLocalizedString("stream_orientation_landscape", comment: "가로")).tag(StreamOrientation.landscape)
+                        Text(NSLocalizedString("stream_orientation_portrait", comment: "세로")).tag(StreamOrientation.portrait)
+                    }
+                    .pickerStyle(.segmented)
+                    .disabled(isOrientationLocked)
+
+                    if isOrientationLocked {
+                        Text(NSLocalizedString("stream_orientation_locked_message", comment: "방송 중에는 방향을 바꿀 수 없습니다. 다음 방송 전에 변경해주세요."))
+                            .font(.caption2)
+                            .foregroundColor(.orange)
+                    }
+                }
+
                 // 해상도 선택
                 VStack(alignment: .leading, spacing: 8) {
                     Text(NSLocalizedString("resolution", comment: "해상도"))
@@ -319,31 +376,33 @@ struct VideoSettingsSectionView: View {
                         // 480p 버튼
                         ResolutionButton(
                             title: "480p",
-                            subtitle: "848×480",
-                            isSelected: currentResolution == .resolution480p,
+                            subtitle: resolutionSubtitle(for: .p480),
+                            isSelected: currentResolutionClass == .p480,
+                            isEnabled: !isOrientationLocked,
                             action: {
-                                setResolution(.resolution480p)
+                                setResolution(.p480)
                             }
                         )
                         
                         // 720p 버튼
                         ResolutionButton(
                             title: "720p",
-                            subtitle: "1280×720",
-                            isSelected: currentResolution == .resolution720p,
+                            subtitle: resolutionSubtitle(for: .p720),
+                            isSelected: currentResolutionClass == .p720,
+                            isEnabled: !isOrientationLocked,
                             action: {
-                                setResolution(.resolution720p)
+                                setResolution(.p720)
                             }
                         )
                         
                         // 1080p 버튼 (고성능 iPad 권장)
                         ResolutionButton(
                             title: "1080p",
-                            subtitle: "1920×1080",
-                            isSelected: currentResolution == .resolution1080p,
-                            isEnabled: true,
+                            subtitle: resolutionSubtitle(for: .p1080),
+                            isSelected: currentResolutionClass == .p1080,
+                            isEnabled: !isOrientationLocked,
                             action: {
-                                setResolution(.resolution1080p)
+                                setResolution(.p1080)
                             }
                         )
                     }
@@ -360,7 +419,7 @@ struct VideoSettingsSectionView: View {
                             title: "24fps",
                             frameRate: 24,
                             isSelected: viewModel.settings.frameRate == 24,
-                            isEnabled: isFrameRateSupported(24),
+                            isEnabled: !isOrientationLocked && isFrameRateSupported(24),
                             action: {
                                 setFrameRate(24)
                             }
@@ -370,7 +429,7 @@ struct VideoSettingsSectionView: View {
                             title: "30fps",
                             frameRate: 30,
                             isSelected: viewModel.settings.frameRate == 30,
-                            isEnabled: isFrameRateSupported(30),
+                            isEnabled: !isOrientationLocked && isFrameRateSupported(30),
                             action: {
                                 setFrameRate(30)
                             }
@@ -380,7 +439,7 @@ struct VideoSettingsSectionView: View {
                             title: "60fps",
                             frameRate: 60,
                             isSelected: viewModel.settings.frameRate == 60,
-                            isEnabled: isFrameRateSupported(60),
+                            isEnabled: !isOrientationLocked && isFrameRateSupported(60),
                             action: {
                                 setFrameRate(60)
                             }
@@ -405,8 +464,13 @@ struct VideoSettingsSectionView: View {
                     // 비트레이트 슬라이더
                     Slider(value: Binding(
                         get: { Double(viewModel.settings.videoBitrate) },
-                        set: { viewModel.settings.videoBitrate = Int($0) }
+                        set: { newValue in
+                            viewModel.updateSettings { settings in
+                                settings.videoBitrate = Int(newValue)
+                            }
+                        }
                     ), in: 500...20000, step: 100)
+                    .disabled(isOrientationLocked)
                     
                     // YouTube Live 권장사항 및 경고
                     bitrateWarningView
@@ -414,7 +478,7 @@ struct VideoSettingsSectionView: View {
             }
         }
         .onAppear {
-            normalizeFrameRateIfNeeded(for: currentResolution)
+            normalizeFrameRateIfNeeded(for: currentResolutionClass)
         }
     }
 }

--- a/USBExternalCamera/Views/LiveStream/LiveStreamSettingsView.swift
+++ b/USBExternalCamera/Views/LiveStream/LiveStreamSettingsView.swift
@@ -24,7 +24,7 @@ struct LiveStreamSettingsView: View {
     var body: some View {
         NavigationView {
             ScrollView {
-                VStack(spacing: 20) {
+                LazyVStack(spacing: 20) {
                     // 상태 표시
                     StatusSectionView(viewModel: viewModel)
                     

--- a/USBExternalCamera/Views/LiveStream/LiveStreamSettingsYouTubePresetSection.swift
+++ b/USBExternalCamera/Views/LiveStream/LiveStreamSettingsYouTubePresetSection.swift
@@ -6,6 +6,15 @@ import LiveStreamingCore
 /// 유튜브 권장 송출 셋업 프리셋 섹션
 struct YouTubePresetSectionView: View {
     @ObservedObject var viewModel: LiveStreamViewModel
+
+    private var isPresetLocked: Bool {
+        switch viewModel.status {
+        case .connected, .streaming, .connecting, .disconnecting:
+            return true
+        case .idle, .error:
+            return false
+        }
+    }
     
     var body: some View {
         SettingsSectionView(title: NSLocalizedString("youtube_preset_title", comment: "YouTube 권장 송출 설정"), icon: "play.rectangle.fill") {
@@ -34,6 +43,18 @@ struct YouTubePresetSectionView: View {
                             Spacer()
                         }
                     }
+
+                    if isPresetLocked {
+                        HStack {
+                            Image(systemName: "lock.fill")
+                                .foregroundColor(.orange)
+                                .font(.caption)
+                            Text(NSLocalizedString("stream_orientation_locked_message", comment: "방송 중에는 방향을 바꿀 수 없습니다. 다음 방송 전에 변경해주세요."))
+                                .font(.caption)
+                                .foregroundColor(.orange)
+                            Spacer()
+                        }
+                    }
                 }
                 .padding(.bottom, 4)
                 
@@ -42,11 +63,12 @@ struct YouTubePresetSectionView: View {
                     // 480p 프리셋
                     YouTubePresetCard(
                         title: "480p (SD)",
-                                                    subtitle: "848×480 • 30fps • 4,000 kbps",
+                        subtitle: presetSubtitle(.sd480p),
                         description: "저화질 • 안정적인 연결",
                         icon: "play.square",
                         color: .orange,
                         isSelected: isCurrentPreset(.sd480p),
+                        isEnabled: !isPresetLocked,
                         action: {
                             applyYouTubePreset(.sd480p)
                         }
@@ -55,11 +77,12 @@ struct YouTubePresetSectionView: View {
                     // 720p 프리셋
                     YouTubePresetCard(
                         title: "720p (HD)",
-                        subtitle: "1280×720 • 30fps • 4,000 kbps",
+                        subtitle: presetSubtitle(.hd720p),
                         description: "표준화질 • 권장 설정",
                         icon: "play.square.fill",
                         color: .green,
                         isSelected: isCurrentPreset(.hd720p),
+                        isEnabled: !isPresetLocked,
                         action: {
                             applyYouTubePreset(.hd720p)
                         }
@@ -68,12 +91,12 @@ struct YouTubePresetSectionView: View {
                     // 1080p 프리셋 (고성능 iPad 권장)
                     YouTubePresetCard(
                         title: "1080p (Full HD)",
-                        subtitle: "1920×1080 • 30fps • 10,000 kbps",
+                        subtitle: presetSubtitle(.fhd1080p),
                         description: NSLocalizedString("high_quality_streaming", comment: "고화질 스트리밍"),
                         icon: "play.square.stack",
                         color: .purple,
                         isSelected: isCurrentPreset(.fhd1080p),
-                        isEnabled: true,
+                        isEnabled: !isPresetLocked,
                         action: {
                             applyYouTubePreset(.fhd1080p)
                         }
@@ -99,9 +122,19 @@ struct YouTubePresetSectionView: View {
     }
     
     // MARK: - Helper Methods
+
+    private func presetSubtitle(_ preset: YouTubeLivePreset) -> String {
+        let settings = preset.settings(for: viewModel.settings.streamOrientation)
+        let recommendedBitrate = YouTubeBitrateAdvisor.recommendedH264Bitrate(
+            width: settings.width,
+            height: settings.height,
+            frameRate: settings.frameRate
+        )
+        return "\(settings.width)×\(settings.height) • \(settings.frameRate)fps • \(recommendedBitrate) kbps"
+    }
     
     private func isCurrentPreset(_ preset: YouTubeLivePreset) -> Bool {
-        let settings = preset.settings
+        let settings = preset.settings(for: viewModel.settings.streamOrientation)
         let recommendedBitrate = YouTubeBitrateAdvisor.recommendedH264Bitrate(
             width: settings.width,
             height: settings.height,
@@ -126,28 +159,8 @@ struct YouTubePresetSectionView: View {
     }
     
     private func applyYouTubePreset(_ preset: YouTubeLivePreset) {
-        let settings = preset.settings
-        let recommendedBitrate = YouTubeBitrateAdvisor.recommendedH264Bitrate(
-            width: settings.width,
-            height: settings.height,
-            frameRate: settings.frameRate
-        )
-        
-        viewModel.settings.videoWidth = settings.width
-        viewModel.settings.videoHeight = settings.height
-        viewModel.settings.frameRate = settings.frameRate
-        viewModel.settings.videoBitrate = recommendedBitrate
-        viewModel.settings.audioBitrate = 128
-        
-        // 유튜브 최적화 기본 설정
-        viewModel.settings.videoEncoder = "H.264"
-        viewModel.settings.audioEncoder = "AAC"
-        viewModel.settings.autoReconnect = true
-        viewModel.settings.connectionTimeout = 30
-        viewModel.settings.bufferSize = 3
-        
-        // 설정 저장
-        viewModel.saveSettings()
+        guard !isPresetLocked else { return }
+        viewModel.applyYouTubePreset(preset)
     }
 }
 

--- a/USBExternalCamera/Views/TextOverlay/TextOverlayControlView.swift
+++ b/USBExternalCamera/Views/TextOverlay/TextOverlayControlView.swift
@@ -5,35 +5,37 @@ import SwiftUI
 /// 텍스트 표시/숨김 토글 및 텍스트 추가 버튼을 제공하는 컴포넌트입니다.
 /// 프리뷰 옆에 세로로 배치되어 사용자가 텍스트 오버레이를 제어할 수 있습니다.
 struct TextOverlayControlView: View {
-    @ObservedObject var viewModel: MainViewModel
+    let isTextOverlayVisible: Bool
+    let onToggleTextOverlay: () -> Void
+    let onShowTextSettings: () -> Void
     
     var body: some View {
         VStack(spacing: 8) {
             // 텍스트 표시/숨김 토글 버튼
             Button(action: {
-                viewModel.toggleTextOverlay()
+                onToggleTextOverlay()
             }) {
                 VStack(spacing: 4) {
-                    Image(systemName: viewModel.showTextOverlay ? "text.bubble.fill" : "text.bubble")
+                    Image(systemName: isTextOverlayVisible ? "text.bubble.fill" : "text.bubble")
                         .font(.system(size: 20))
-                    Text(viewModel.showTextOverlay ? NSLocalizedString("text_overlay_hide", comment: "텍스트 숨김") : NSLocalizedString("text_overlay_show", comment: "텍스트 표시"))
+                    Text(isTextOverlayVisible ? NSLocalizedString("text_overlay_hide", comment: "텍스트 숨김") : NSLocalizedString("text_overlay_show", comment: "텍스트 표시"))
                         .font(.caption2)
                         .multilineTextAlignment(.center)
                 }
-                .foregroundColor(viewModel.showTextOverlay ? .white : .blue)
+                .foregroundColor(isTextOverlayVisible ? .white : .blue)
                 .padding(.horizontal, 10)
                 .padding(.vertical, 10)
                 .frame(width: 100, height: 60)
                 .background(
                     RoundedRectangle(cornerRadius: 8)
-                        .fill(viewModel.showTextOverlay ? Color.blue : Color.blue.opacity(0.1))
+                        .fill(isTextOverlayVisible ? Color.blue : Color.blue.opacity(0.1))
                 )
             }
             .buttonStyle(.plain)
             
             // 텍스트 설정 버튼
             Button(action: {
-                viewModel.showTextSettings()
+                onShowTextSettings()
             }) {
                 VStack(spacing: 4) {
                     Image(systemName: "textformat.alt")

--- a/USBExternalCameraTests/USBExternalCameraTests.swift
+++ b/USBExternalCameraTests/USBExternalCameraTests.swift
@@ -6,12 +6,45 @@
 //
 
 import Testing
+import CoreGraphics
+import LiveStreamingCore
 @testable import USBExternalCamera
 
 struct USBExternalCameraTests {
 
-    @Test func example() async throws {
-        // Write your test here and use APIs like `#expect(...)` to check expected conditions.
+    @MainActor
+    @Test func getOptimalCaptureSizeKeepsPresetPortraitTarget() async throws {
+        let previewView = CameraPreviewUIView(frame: .zero)
+
+        previewView.setStreamingTargetSize(CGSize(width: 720, height: 1280))
+
+        #expect(previewView.getOptimalCaptureSize() == CGSize(width: 720, height: 1280))
+    }
+
+    @MainActor
+    @Test func getOptimalCaptureSizeAlignsCustomTargetToMultiplesOf16() async throws {
+        let previewView = CameraPreviewUIView(frame: .zero)
+
+        previewView.setStreamingTargetSize(CGSize(width: 721, height: 1281))
+
+        #expect(previewView.getOptimalCaptureSize() == CGSize(width: 736, height: 1296))
+    }
+
+    @MainActor
+    @Test func calculateCameraPreviewRectUsesPortraitAspectRatio() async throws {
+        let previewView = CameraPreviewUIView(frame: .zero)
+        var settings = LiveStreamSettings()
+        settings.streamOrientation = .portrait
+        settings.videoWidth = 720
+        settings.videoHeight = 1280
+        previewView.streamingSettings = settings
+
+        let rect = previewView.calculateCameraPreviewRect(in: CGSize(width: 1000, height: 1000))
+
+        #expect(abs(rect.width - 562.5) < 0.001)
+        #expect(abs(rect.height - 1000) < 0.001)
+        #expect(abs(rect.minX - 218.75) < 0.001)
+        #expect(abs(rect.minY) < 0.001)
     }
 
 }


### PR DESCRIPTION
## Summary
`LiveStreamSettingsModel`에 `streamOrientation`(`.landscape` / `.portrait`) 속성을 추가하고, UI·프리뷰·송출 파이프라인 전반이 세로 모드(9:16)를 일관되게 다루도록 정리합니다.

### Core (LiveStreamingCore)
- 신규 `StreamingOrientationSupport.swift`
  - `StreamOrientation` / `StreamRotationPolicy` / `StreamLayoutProfile`
  - `StreamResolutionClass` / `StreamResolutionDescriptor` (480/720/1080/4k/custom)
- `LiveStreamSettingsModel.streamOrientation` 추가, 해상도 프리셋이 방향을 인지해 width/height 스왑.
- `normalizedResolutionClass` 헬퍼로 YouTube 비트레이트 추천 로직을 resolutionClass 기반으로 재구성.

### 앱 (UI)
- `LiveStreamSettingsView`에 **송출 방향** 토글(가로/세로) + 방송 중 변경 금지 안내 문자열(`stream_orientation_locked_message`).
- `DetailView`를 방향별로 분기하여 포커스 모드 레이아웃을 세로에서도 깔끔하게 정렬.
- `CameraPreviewUIView`: 세로 9:16 렌더링, 90° 회전 파이프라인, aspect-fill 처리.
- `CameraPreviewView` / `CameraSessionManager` / `CameraScreenCapture`: 방향 전환 시 캡처 타이밍 재동기화.
- Localizable.strings (en/ko)에 관련 키 추가.

### 안정화
- 프리뷰 레이아웃 전환 시 깜빡임/크래시 방지 (DetailView +621, CameraPreviewUIView +106).
- 오디오 피크 미터가 방향 레이아웃에 맞게 재배치.

## 기반 PR
이 PR은 #17 (HaishinKit 2.2.5 마이그레이션) 위에 쌓여 있습니다. #17이 먼저 머지되어야 diff가 깔끔합니다.

## 호환성 메모
- `streamOrientation`은 저장 시 UserDefaults(`LiveStream.streamOrientation`)에 `landscape|portrait` 문자열로 보존. 미설정 사용자는 `videoHeight > videoWidth` 여부로 자동 판정되어 기존 동작을 유지합니다.

## Test plan
- [x] iPad Pro 12.9" 4세대(iOS 26.4.1) 실기기에서 세로 모드 프리뷰가 9:16으로 맞는지 확인
- [x] 설정 → 송출 방향 전환 후 출력 영상이 세로 비율로 나가는지 YouTube Studio로 확인
- [x] 방송 중 방향 토글이 잠기는지 확인(잠금 메시지 노출)
- [x] 마이크 입력·음소거 동작 확인 (PR #17의 `.single` 수정과 함께)
- [ ] 가로↔세로 반복 토글 시 프리뷰 깜빡임/레이아웃 고장 없는지 회귀 확인