### PR TITLE
fix: 카메라 전환·디바이스 회전 이후 송출 방향 회귀 수정

### DIFF
--- a/USBExternalCamera/Managers/CameraSessionManager.swift
+++ b/USBExternalCamera/Managers/CameraSessionManager.swift
@@ -171,36 +171,38 @@ public final class CameraSessionManager: NSObject, CameraSessionManaging, @unche
         isMirrored: Bool
     ) {
         sessionQueue.async { [weak self] in
-            guard let self, let connection = self.videoOutput.connection(with: .video) else { return }
-
-            let configurationKey = self.makeVideoOutputConfigurationKey(
-                connection: connection,
+            self?.applyVideoOutputConfigurationOnSessionQueue(
                 rotationAngle: rotationAngle,
                 orientation: orientation,
                 isMirrored: isMirrored
             )
+        }
+    }
 
-            guard self.lastAppliedVideoOutputConfigurationKey != configurationKey else {
-                return
-            }
+    /// `updateVideoOutputConfiguration` 의 실제 구현. 호출자는 반드시 `sessionQueue` 위에 있어야 한다.
+    /// `switchToCamera` 처럼 이미 sessionQueue 위에서 실행 중인 경우, 재-dispatch 로 인한 한 틱 지연을
+    /// 피하기 위해 이 메서드를 직접 호출해 같은 block 내에서 동기 적용한다.
+    private func applyVideoOutputConfigurationOnSessionQueue(
+        rotationAngle: CGFloat?,
+        orientation: PreviewVideoOrientation?,
+        isMirrored: Bool
+    ) {
+        guard let connection = self.videoOutput.connection(with: .video) else { return }
 
-            if #available(iOS 17.0, *) {
-                if let rotationAngle, connection.isVideoRotationAngleSupported(rotationAngle) {
-                    connection.videoRotationAngle = rotationAngle
-                } else if let orientation, connection.isVideoOrientationSupported {
-                    switch orientation {
-                    case .portrait:
-                        connection.videoOrientation = .portrait
-                    case .portraitUpsideDown:
-                        connection.videoOrientation = .portraitUpsideDown
-                    case .landscapeRight:
-                        connection.videoOrientation = .landscapeRight
-                    case .landscapeLeft:
-                        connection.videoOrientation = .landscapeLeft
-                    }
-                } else if connection.isVideoRotationAngleSupported(0) {
-                    connection.videoRotationAngle = 0
-                }
+        let configurationKey = self.makeVideoOutputConfigurationKey(
+            connection: connection,
+            rotationAngle: rotationAngle,
+            orientation: orientation,
+            isMirrored: isMirrored
+        )
+
+        guard self.lastAppliedVideoOutputConfigurationKey != configurationKey else {
+            return
+        }
+
+        if #available(iOS 17.0, *) {
+            if let rotationAngle, connection.isVideoRotationAngleSupported(rotationAngle) {
+                connection.videoRotationAngle = rotationAngle
             } else if let orientation, connection.isVideoOrientationSupported {
                 switch orientation {
                 case .portrait:
@@ -212,19 +214,32 @@ public final class CameraSessionManager: NSObject, CameraSessionManaging, @unche
                 case .landscapeLeft:
                     connection.videoOrientation = .landscapeLeft
                 }
+            } else if connection.isVideoRotationAngleSupported(0) {
+                connection.videoRotationAngle = 0
             }
-
-            if connection.isVideoMirroringSupported {
-                connection.automaticallyAdjustsVideoMirroring = false
-                connection.isVideoMirrored = isMirrored
+        } else if let orientation, connection.isVideoOrientationSupported {
+            switch orientation {
+            case .portrait:
+                connection.videoOrientation = .portrait
+            case .portraitUpsideDown:
+                connection.videoOrientation = .portraitUpsideDown
+            case .landscapeRight:
+                connection.videoOrientation = .landscapeRight
+            case .landscapeLeft:
+                connection.videoOrientation = .landscapeLeft
             }
-
-            self.lastAppliedVideoOutputConfigurationKey = configurationKey
-            self.lastRequestedRotationAngle = rotationAngle
-            self.lastRequestedOrientation = orientation
-            self.lastRequestedIsMirrored = isMirrored
-            self.hasLastRequestedConfiguration = true
         }
+
+        if connection.isVideoMirroringSupported {
+            connection.automaticallyAdjustsVideoMirroring = false
+            connection.isVideoMirrored = isMirrored
+        }
+
+        self.lastAppliedVideoOutputConfigurationKey = configurationKey
+        self.lastRequestedRotationAngle = rotationAngle
+        self.lastRequestedOrientation = orientation
+        self.lastRequestedIsMirrored = isMirrored
+        self.hasLastRequestedConfiguration = true
     }
 
     private func makeVideoOutputConfigurationKey(
@@ -504,16 +519,15 @@ public final class CameraSessionManager: NSObject, CameraSessionManaging, @unche
 
             // 새 입력과 함께 생성되는 AVCaptureConnection 은 기본 orientation 을 갖기 때문에,
             // 직전까지 적용돼 있던 rotation / orientation / mirroring 을 다시 씌워준다.
+            // 이미 sessionQueue 위에서 실행 중이므로 재-dispatch 로 한 틱 밀리지 않도록
+            // 동기 헬퍼를 직접 호출해 같은 block 내에서 즉시 적용.
             // 캐시 키는 connection ObjectIdentifier 기반이라 새 connection 에서는 자동으로 무효화된다.
             self.lastAppliedVideoOutputConfigurationKey = nil
             if self.hasLastRequestedConfiguration {
-                let rotation = self.lastRequestedRotationAngle
-                let orientation = self.lastRequestedOrientation
-                let mirrored = self.lastRequestedIsMirrored
-                self.updateVideoOutputConfiguration(
-                    rotationAngle: rotation,
-                    orientation: orientation,
-                    isMirrored: mirrored
+                self.applyVideoOutputConfigurationOnSessionQueue(
+                    rotationAngle: self.lastRequestedRotationAngle,
+                    orientation: self.lastRequestedOrientation,
+                    isMirrored: self.lastRequestedIsMirrored
                 )
             }
 

--- a/USBExternalCamera/Managers/CameraSessionManager.swift
+++ b/USBExternalCamera/Managers/CameraSessionManager.swift
@@ -11,7 +11,8 @@ public enum PreviewVideoOrientation: Sendable {
 
 extension Notification.Name {
     /// CameraSessionManager 가 새 카메라로 입력 교체를 마쳤을 때 발송.
-    /// userInfo["device"] 에 새로 연결된 AVCaptureDevice 가 포함된다.
+    /// 입력 교체와 함께 새 AVCaptureConnection 이 생성되므로 뷰/매니저 측에서
+    /// 프리뷰 orientation·비디오 출력 config 를 다시 적용할 기회를 얻기 위한 용도.
     static let cameraSessionDidSwitchCamera = Notification.Name(
         "com.heavyarm.usbexternalcamera.cameraSessionDidSwitchCamera"
     )
@@ -95,12 +96,14 @@ public final class CameraSessionManager: NSObject, CameraSessionManaging, @unche
     /// 마지막으로 적용한 비디오 출력 연결 설정 (중복 적용 방지용 캐시)
     private var lastAppliedVideoOutputConfigurationKey: String?
 
-    /// 카메라 전환 직후에도 방향/미러링을 복원할 수 있도록 최근 입력값을 보관.
+    /// 카메라 전환 직후에도 방향/미러링을 복원할 수 있도록 최근 입력값을 묶어 보관.
     /// `updateVideoOutputConfiguration` 이 적용에 성공할 때마다 갱신된다.
-    private var lastRequestedRotationAngle: CGFloat?
-    private var lastRequestedOrientation: PreviewVideoOrientation?
-    private var lastRequestedIsMirrored: Bool = false
-    private var hasLastRequestedConfiguration: Bool = false
+    private struct CachedVideoOutputConfiguration {
+        let rotationAngle: CGFloat?
+        let orientation: PreviewVideoOrientation?
+        let isMirrored: Bool
+    }
+    private var cachedVideoOutputConfiguration: CachedVideoOutputConfiguration?
     
     /// 초기화 및 기본 세션 설정
     /// - 세션 프리셋과 비디오 출력을 초기화
@@ -203,31 +206,13 @@ public final class CameraSessionManager: NSObject, CameraSessionManaging, @unche
         if #available(iOS 17.0, *) {
             if let rotationAngle, connection.isVideoRotationAngleSupported(rotationAngle) {
                 connection.videoRotationAngle = rotationAngle
-            } else if let orientation, connection.isVideoOrientationSupported {
-                switch orientation {
-                case .portrait:
-                    connection.videoOrientation = .portrait
-                case .portraitUpsideDown:
-                    connection.videoOrientation = .portraitUpsideDown
-                case .landscapeRight:
-                    connection.videoOrientation = .landscapeRight
-                case .landscapeLeft:
-                    connection.videoOrientation = .landscapeLeft
-                }
-            } else if connection.isVideoRotationAngleSupported(0) {
+            } else if !applyLegacyVideoOrientation(orientation, to: connection),
+                connection.isVideoRotationAngleSupported(0)
+            {
                 connection.videoRotationAngle = 0
             }
-        } else if let orientation, connection.isVideoOrientationSupported {
-            switch orientation {
-            case .portrait:
-                connection.videoOrientation = .portrait
-            case .portraitUpsideDown:
-                connection.videoOrientation = .portraitUpsideDown
-            case .landscapeRight:
-                connection.videoOrientation = .landscapeRight
-            case .landscapeLeft:
-                connection.videoOrientation = .landscapeLeft
-            }
+        } else {
+            _ = applyLegacyVideoOrientation(orientation, to: connection)
         }
 
         if connection.isVideoMirroringSupported {
@@ -236,10 +221,33 @@ public final class CameraSessionManager: NSObject, CameraSessionManaging, @unche
         }
 
         self.lastAppliedVideoOutputConfigurationKey = configurationKey
-        self.lastRequestedRotationAngle = rotationAngle
-        self.lastRequestedOrientation = orientation
-        self.lastRequestedIsMirrored = isMirrored
-        self.hasLastRequestedConfiguration = true
+        self.cachedVideoOutputConfiguration = CachedVideoOutputConfiguration(
+            rotationAngle: rotationAngle,
+            orientation: orientation,
+            isMirrored: isMirrored
+        )
+    }
+
+    /// `PreviewVideoOrientation` 을 `connection.videoOrientation` 에 적용.
+    /// iOS 17 이상에서는 회전 각도 API 가 우선이고 이 경로는 fallback 으로만 사용된다.
+    /// @discardableResult 를 붙여 iOS 17+ 분기에서 "미적용 여부" 판별에 활용.
+    @discardableResult
+    private func applyLegacyVideoOrientation(
+        _ orientation: PreviewVideoOrientation?,
+        to connection: AVCaptureConnection
+    ) -> Bool {
+        guard let orientation, connection.isVideoOrientationSupported else { return false }
+        switch orientation {
+        case .portrait:
+            connection.videoOrientation = .portrait
+        case .portraitUpsideDown:
+            connection.videoOrientation = .portraitUpsideDown
+        case .landscapeRight:
+            connection.videoOrientation = .landscapeRight
+        case .landscapeLeft:
+            connection.videoOrientation = .landscapeLeft
+        }
+        return true
     }
 
     private func makeVideoOutputConfigurationKey(
@@ -523,11 +531,11 @@ public final class CameraSessionManager: NSObject, CameraSessionManaging, @unche
             // 동기 헬퍼를 직접 호출해 같은 block 내에서 즉시 적용.
             // 캐시 키는 connection ObjectIdentifier 기반이라 새 connection 에서는 자동으로 무효화된다.
             self.lastAppliedVideoOutputConfigurationKey = nil
-            if self.hasLastRequestedConfiguration {
+            if let cached = self.cachedVideoOutputConfiguration {
                 self.applyVideoOutputConfigurationOnSessionQueue(
-                    rotationAngle: self.lastRequestedRotationAngle,
-                    orientation: self.lastRequestedOrientation,
-                    isMirrored: self.lastRequestedIsMirrored
+                    rotationAngle: cached.rotationAngle,
+                    orientation: cached.orientation,
+                    isMirrored: cached.isMirrored
                 )
             }
 
@@ -539,11 +547,7 @@ public final class CameraSessionManager: NSObject, CameraSessionManaging, @unche
 
             // 프리뷰 레이어는 AVCaptureVideoPreviewLayer 의 connection 이 새 입력에 맞춰 재생성될 수 있으므로,
             // 뷰 측에서 orientation 을 다시 적용하도록 notification 을 발송.
-            NotificationCenter.default.post(
-                name: .cameraSessionDidSwitchCamera,
-                object: self,
-                userInfo: ["device": camera.device]
-            )
+            NotificationCenter.default.post(name: .cameraSessionDidSwitchCamera, object: self)
         }
     }
     

--- a/USBExternalCamera/Managers/CameraSessionManager.swift
+++ b/USBExternalCamera/Managers/CameraSessionManager.swift
@@ -9,6 +9,14 @@ public enum PreviewVideoOrientation: Sendable {
     case landscapeLeft
 }
 
+extension Notification.Name {
+    /// CameraSessionManager 가 새 카메라로 입력 교체를 마쳤을 때 발송.
+    /// userInfo["device"] 에 새로 연결된 AVCaptureDevice 가 포함된다.
+    static let cameraSessionDidSwitchCamera = Notification.Name(
+        "com.heavyarm.usbexternalcamera.cameraSessionDidSwitchCamera"
+    )
+}
+
 /// 카메라 전환 완료를 알리는 델리게이트
 public protocol CameraSwitchDelegate: AnyObject {
     /// 카메라 전환이 완료되었을 때 호출
@@ -86,6 +94,13 @@ public final class CameraSessionManager: NSObject, CameraSessionManaging, @unche
 
     /// 마지막으로 적용한 비디오 출력 연결 설정 (중복 적용 방지용 캐시)
     private var lastAppliedVideoOutputConfigurationKey: String?
+
+    /// 카메라 전환 직후에도 방향/미러링을 복원할 수 있도록 최근 입력값을 보관.
+    /// `updateVideoOutputConfiguration` 이 적용에 성공할 때마다 갱신된다.
+    private var lastRequestedRotationAngle: CGFloat?
+    private var lastRequestedOrientation: PreviewVideoOrientation?
+    private var lastRequestedIsMirrored: Bool = false
+    private var hasLastRequestedConfiguration: Bool = false
     
     /// 초기화 및 기본 세션 설정
     /// - 세션 프리셋과 비디오 출력을 초기화
@@ -205,6 +220,10 @@ public final class CameraSessionManager: NSObject, CameraSessionManaging, @unche
             }
 
             self.lastAppliedVideoOutputConfigurationKey = configurationKey
+            self.lastRequestedRotationAngle = rotationAngle
+            self.lastRequestedOrientation = orientation
+            self.lastRequestedIsMirrored = isMirrored
+            self.hasLastRequestedConfiguration = true
         }
     }
 
@@ -482,12 +501,35 @@ public final class CameraSessionManager: NSObject, CameraSessionManaging, @unche
             self.lastFrameTime = CACurrentMediaTime()
             
             logInfo("🎥 카메라 전환 완료: \(camera.name)", category: .camera)
-            
+
+            // 새 입력과 함께 생성되는 AVCaptureConnection 은 기본 orientation 을 갖기 때문에,
+            // 직전까지 적용돼 있던 rotation / orientation / mirroring 을 다시 씌워준다.
+            // 캐시 키는 connection ObjectIdentifier 기반이라 새 connection 에서는 자동으로 무효화된다.
+            self.lastAppliedVideoOutputConfigurationKey = nil
+            if self.hasLastRequestedConfiguration {
+                let rotation = self.lastRequestedRotationAngle
+                let orientation = self.lastRequestedOrientation
+                let mirrored = self.lastRequestedIsMirrored
+                self.updateVideoOutputConfiguration(
+                    rotationAngle: rotation,
+                    orientation: orientation,
+                    isMirrored: mirrored
+                )
+            }
+
             // 카메라 전환 완료를 델리게이트에 알림 (스트리밍 동기화용)
             Task { @MainActor [weak self] in
                 guard let self = self else { return }
                 await self.switchDelegate?.didSwitchCamera(to: camera.device, session: self.captureSession)
             }
+
+            // 프리뷰 레이어는 AVCaptureVideoPreviewLayer 의 connection 이 새 입력에 맞춰 재생성될 수 있으므로,
+            // 뷰 측에서 orientation 을 다시 적용하도록 notification 을 발송.
+            NotificationCenter.default.post(
+                name: .cameraSessionDidSwitchCamera,
+                object: self,
+                userInfo: ["device": camera.device]
+            )
         }
     }
     

--- a/USBExternalCamera/ViewModels/LiveStreamViewModel+ScreenCapture.swift
+++ b/USBExternalCamera/ViewModels/LiveStreamViewModel+ScreenCapture.swift
@@ -33,18 +33,15 @@ extension LiveStreamViewModel {
       startSettings.setStreamOrientation(resolvedOrientation)
     }
 
-    // Console.app / Xcode 콘솔에서 모두 보이도록 NSLog 사용 (privacy 필터 영향 없음)
+    // Console.app / Xcode 콘솔에서 모두 보이도록 NSLog + Swift 문자열 보간 사용.
+    // (Int 는 64bit 이므로 printf-style %d 대신 문자열 보간이 안전.)
     NSLog(
-      "[USBCam] 송출 시작 방향 동기화: resolved=%@, stored=%@, "
-        + "startSettings=%@ %dx%d (fg=%@, any=%@, device=%@)",
-      resolvedOrientation?.rawValue ?? "nil",
-      settings.streamOrientation.rawValue,
-      startSettings.streamOrientation.rawValue,
-      startSettings.videoWidth,
-      startSettings.videoHeight,
-      describeForegroundInterfaceOrientation(),
-      describeAnyInterfaceOrientation(),
-      describeCurrentDeviceOrientation()
+      "[USBCam] 송출 시작 방향 동기화: resolved=\(resolvedOrientation?.rawValue ?? "nil"), "
+        + "stored=\(settings.streamOrientation.rawValue), "
+        + "startSettings=\(startSettings.streamOrientation.rawValue) "
+        + "\(startSettings.videoWidth)x\(startSettings.videoHeight) "
+        + "(keyScene=\(describeKeySceneInterfaceOrientation()), "
+        + "device=\(describeCurrentDeviceOrientation()))"
     )
 
     // UI 에도 반영 (다음 스트림 시작 시 기본값으로 사용되고, 설정 화면에도 최신 상태 표시)
@@ -76,10 +73,9 @@ extension LiveStreamViewModel {
     guard settings.streamOrientation != resolved else { return }
 
     NSLog(
-      "[USBCam] orientation observer: %@ → %@ (device=%@)",
-      settings.streamOrientation.rawValue,
-      resolved.rawValue,
-      describeCurrentDeviceOrientation()
+      "[USBCam] orientation observer: "
+        + "\(settings.streamOrientation.rawValue) → \(resolved.rawValue) "
+        + "(device=\(describeCurrentDeviceOrientation()))"
     )
 
     updateSettings(
@@ -90,51 +86,58 @@ extension LiveStreamViewModel {
 
   @MainActor
   private func detectDeviceStreamOrientation() -> StreamOrientation? {
-    // 우선순위: foregroundActive scene.interfaceOrientation → 다른 scene → UIDevice.orientation
-    let scenes = UIApplication.shared.connectedScenes.compactMap { $0 as? UIWindowScene }
-    if let fg = scenes.first(where: { $0.activationState == .foregroundActive }),
-      fg.interfaceOrientation != .unknown
-    {
-      return streamOrientation(from: fg.interfaceOrientation)
+    // 우선순위:
+    //  1) keyWindow 를 호스팅하는 foregroundActive UIWindowScene
+    //     - `connectedScenes` 는 unordered set 이므로 멀티윈도우/Stage Manager 환경에서
+    //       key 를 가진 scene 을 명시적으로 골라야 현재 스트리밍 UI 가 속한 scene 을 얻을 수 있음
+    //  2) 아무 foregroundActive scene
+    //  3) orientation 이 확정된 아무 scene
+    //  4) UIDevice.current.orientation
+    if let keyScene = keyWindowScene(), let orientation = streamOrientation(from: keyScene.interfaceOrientation) {
+      return orientation
     }
-    if let any = scenes.first(where: { $0.interfaceOrientation != .unknown }) {
-      return streamOrientation(from: any.interfaceOrientation)
+
+    let scenes = UIApplication.shared.connectedScenes.compactMap { $0 as? UIWindowScene }
+    if let fg = scenes.first(where: { $0.activationState == .foregroundActive && $0.interfaceOrientation != .unknown }),
+      let orientation = streamOrientation(from: fg.interfaceOrientation)
+    {
+      return orientation
+    }
+    if let any = scenes.first(where: { $0.interfaceOrientation != .unknown }),
+      let orientation = streamOrientation(from: any.interfaceOrientation)
+    {
+      return orientation
     }
     return streamOrientation(from: UIDevice.current.orientation)
   }
 
+  /// keyWindow 를 호스팅하는 UIWindowScene. Stage Manager / 멀티윈도우에서
+  /// 현재 사용자 상호작용 대상이 되는 scene 을 명확히 지정하기 위한 헬퍼.
+  @MainActor
+  private func keyWindowScene() -> UIWindowScene? {
+    return UIApplication.shared.connectedScenes
+      .compactMap { $0 as? UIWindowScene }
+      .first(where: { scene in
+        scene.activationState == .foregroundActive
+          && scene.windows.contains(where: { $0.isKeyWindow })
+      })
+  }
+
   private func streamOrientation(from interface: UIInterfaceOrientation) -> StreamOrientation? {
-    switch interface {
-    case .portrait, .portraitUpsideDown: return .portrait
-    case .landscapeLeft, .landscapeRight: return .landscape
-    default: return nil
-    }
+    if interface.isPortrait { return .portrait }
+    if interface.isLandscape { return .landscape }
+    return nil
   }
 
   private func streamOrientation(from device: UIDeviceOrientation) -> StreamOrientation? {
-    switch device {
-    case .portrait, .portraitUpsideDown: return .portrait
-    case .landscapeLeft, .landscapeRight: return .landscape
-    default: return nil
-    }
+    if device.isPortrait { return .portrait }
+    if device.isLandscape { return .landscape }
+    return nil
   }
 
   @MainActor
-  private func describeForegroundInterfaceOrientation() -> String {
-    let orientation = UIApplication.shared.connectedScenes
-      .compactMap { $0 as? UIWindowScene }
-      .first(where: { $0.activationState == .foregroundActive })?
-      .interfaceOrientation
-    return describe(orientation)
-  }
-
-  @MainActor
-  private func describeAnyInterfaceOrientation() -> String {
-    let orientation = UIApplication.shared.connectedScenes
-      .compactMap { $0 as? UIWindowScene }
-      .map { $0.interfaceOrientation }
-      .first(where: { $0 != .unknown })
-    return describe(orientation)
+  private func describeKeySceneInterfaceOrientation() -> String {
+    describe(keyWindowScene()?.interfaceOrientation)
   }
 
   private func describeCurrentDeviceOrientation() -> String {

--- a/USBExternalCamera/ViewModels/LiveStreamViewModel+ScreenCapture.swift
+++ b/USBExternalCamera/ViewModels/LiveStreamViewModel+ScreenCapture.swift
@@ -33,16 +33,14 @@ extension LiveStreamViewModel {
       startSettings.setStreamOrientation(resolvedOrientation)
     }
 
-    // Console.app / Xcode 콘솔에서 모두 보이도록 NSLog + Swift 문자열 보간 사용.
-    // (Int 는 64bit 이므로 printf-style %d 대신 문자열 보간이 안전.)
-    NSLog(
-      "[USBCam] 송출 시작 방향 동기화: resolved=\(resolvedOrientation?.rawValue ?? "nil"), "
+    logInfo(
+      "송출 시작 방향 동기화: resolved=\(resolvedOrientation?.rawValue ?? "nil"), "
         + "stored=\(settings.streamOrientation.rawValue), "
         + "startSettings=\(startSettings.streamOrientation.rawValue) "
-        + "\(startSettings.videoWidth)x\(startSettings.videoHeight) "
-        + "(keyScene=\(describeKeySceneInterfaceOrientation()), "
-        + "device=\(describeCurrentDeviceOrientation()))"
-    )
+        + "\(startSettings.videoWidth)×\(startSettings.videoHeight) "
+        + "(keyScene=\(keyWindowSceneOrientationDescription()), "
+        + "device=\(describeCurrentDeviceOrientation()))",
+      category: .streaming)
 
     // UI 에도 반영 (다음 스트림 시작 시 기본값으로 사용되고, 설정 화면에도 최신 상태 표시)
     if settings.streamOrientation != startSettings.streamOrientation
@@ -72,11 +70,10 @@ extension LiveStreamViewModel {
     guard let resolved = detectDeviceStreamOrientation() else { return }
     guard settings.streamOrientation != resolved else { return }
 
-    NSLog(
-      "[USBCam] orientation observer: "
-        + "\(settings.streamOrientation.rawValue) → \(resolved.rawValue) "
-        + "(device=\(describeCurrentDeviceOrientation()))"
-    )
+    logDebug(
+      "방향 observer: \(settings.streamOrientation.rawValue) → \(resolved.rawValue) "
+        + "(device=\(describeCurrentDeviceOrientation()))",
+      category: .streaming)
 
     updateSettings(
       { $0.setStreamOrientation(resolved) },
@@ -84,43 +81,56 @@ extension LiveStreamViewModel {
     )
   }
 
+  /// `UIApplication.connectedScenes` 는 unordered set 이라 Stage Manager / 멀티윈도우 환경에서
+  /// 현재 스트리밍 UI 가 속한 scene 을 정확히 찾으려면 keyWindow 우선으로 골라야 함.
+  /// 한 번만 순회하도록 후보 scene 들을 단일 pass 로 수집한 뒤 우선순위로 선택한다.
   @MainActor
   private func detectDeviceStreamOrientation() -> StreamOrientation? {
-    // 우선순위:
-    //  1) keyWindow 를 호스팅하는 foregroundActive UIWindowScene
-    //     - `connectedScenes` 는 unordered set 이므로 멀티윈도우/Stage Manager 환경에서
-    //       key 를 가진 scene 을 명시적으로 골라야 현재 스트리밍 UI 가 속한 scene 을 얻을 수 있음
-    //  2) 아무 foregroundActive scene
-    //  3) orientation 이 확정된 아무 scene
-    //  4) UIDevice.current.orientation
-    if let keyScene = keyWindowScene(), let orientation = streamOrientation(from: keyScene.interfaceOrientation) {
-      return orientation
+    var keySceneOrientation: UIInterfaceOrientation?
+    var anyForegroundOrientation: UIInterfaceOrientation?
+    var anyOrientation: UIInterfaceOrientation?
+
+    for scene in UIApplication.shared.connectedScenes {
+      guard let windowScene = scene as? UIWindowScene else { continue }
+      let interfaceOrientation = windowScene.interfaceOrientation
+      guard interfaceOrientation != .unknown else { continue }
+
+      let isForeground = windowScene.activationState == .foregroundActive
+      if isForeground,
+        keySceneOrientation == nil,
+        windowScene.windows.contains(where: { $0.isKeyWindow })
+      {
+        keySceneOrientation = interfaceOrientation
+      }
+      if isForeground, anyForegroundOrientation == nil {
+        anyForegroundOrientation = interfaceOrientation
+      }
+      if anyOrientation == nil {
+        anyOrientation = interfaceOrientation
+      }
     }
 
-    let scenes = UIApplication.shared.connectedScenes.compactMap { $0 as? UIWindowScene }
-    if let fg = scenes.first(where: { $0.activationState == .foregroundActive && $0.interfaceOrientation != .unknown }),
-      let orientation = streamOrientation(from: fg.interfaceOrientation)
-    {
-      return orientation
-    }
-    if let any = scenes.first(where: { $0.interfaceOrientation != .unknown }),
-      let orientation = streamOrientation(from: any.interfaceOrientation)
+    // 우선순위: keyWindow scene > foreground scene > 아무 scene > UIDevice
+    if let resolved = keySceneOrientation ?? anyForegroundOrientation ?? anyOrientation,
+      let orientation = streamOrientation(from: resolved)
     {
       return orientation
     }
     return streamOrientation(from: UIDevice.current.orientation)
   }
 
-  /// keyWindow 를 호스팅하는 UIWindowScene. Stage Manager / 멀티윈도우에서
-  /// 현재 사용자 상호작용 대상이 되는 scene 을 명확히 지정하기 위한 헬퍼.
+  /// 진단 로그용 — 현재 key scene 의 interfaceOrientation 문자열 표현.
   @MainActor
-  private func keyWindowScene() -> UIWindowScene? {
-    return UIApplication.shared.connectedScenes
+  private func keyWindowSceneOrientationDescription() -> String {
+    let orientation = UIApplication.shared.connectedScenes
+      .lazy
       .compactMap { $0 as? UIWindowScene }
       .first(where: { scene in
         scene.activationState == .foregroundActive
           && scene.windows.contains(where: { $0.isKeyWindow })
-      })
+      })?
+      .interfaceOrientation
+    return describe(orientation)
   }
 
   private func streamOrientation(from interface: UIInterfaceOrientation) -> StreamOrientation? {
@@ -133,11 +143,6 @@ extension LiveStreamViewModel {
     if device.isPortrait { return .portrait }
     if device.isLandscape { return .landscape }
     return nil
-  }
-
-  @MainActor
-  private func describeKeySceneInterfaceOrientation() -> String {
-    describe(keyWindowScene()?.interfaceOrientation)
   }
 
   private func describeCurrentDeviceOrientation() -> String {

--- a/USBExternalCamera/ViewModels/LiveStreamViewModel+ScreenCapture.swift
+++ b/USBExternalCamera/ViewModels/LiveStreamViewModel+ScreenCapture.swift
@@ -25,12 +25,141 @@ extension LiveStreamViewModel {
 
     try await prepareAudioCapturePrerequisites()
 
+    // 현재 디바이스 방향과 저장된 streamOrientation 을 비교해 **로컬 struct** 에서 명시적으로 덮어쓰고
+    // 그대로 매니저에 전달. @Published settings 반영 타이밍과 무관하게 즉시 반영되도록 구성.
+    let resolvedOrientation = detectDeviceStreamOrientation()
+    var startSettings = settings
+    if let resolvedOrientation, startSettings.streamOrientation != resolvedOrientation {
+      startSettings.setStreamOrientation(resolvedOrientation)
+    }
+
+    // Console.app / Xcode 콘솔에서 모두 보이도록 NSLog 사용 (privacy 필터 영향 없음)
+    NSLog(
+      "[USBCam] 송출 시작 방향 동기화: resolved=%@, stored=%@, "
+        + "startSettings=%@ %dx%d (fg=%@, any=%@, device=%@)",
+      resolvedOrientation?.rawValue ?? "nil",
+      settings.streamOrientation.rawValue,
+      startSettings.streamOrientation.rawValue,
+      startSettings.videoWidth,
+      startSettings.videoHeight,
+      describeForegroundInterfaceOrientation(),
+      describeAnyInterfaceOrientation(),
+      describeCurrentDeviceOrientation()
+    )
+
+    // UI 에도 반영 (다음 스트림 시작 시 기본값으로 사용되고, 설정 화면에도 최신 상태 표시)
+    if settings.streamOrientation != startSettings.streamOrientation
+      || settings.videoWidth != startSettings.videoWidth
+      || settings.videoHeight != startSettings.videoHeight
+    {
+      settings = startSettings
+    }
+
     logDebug("🔄 [화면캡처] 화면 캡처 스트리밍 시작 중...", category: .streaming)
-    // 화면 캡처 전용 스트리밍 시작 (일반 스트리밍과 다른 메서드 사용)
-    try await haishinKitManager.startScreenCaptureStreaming(with: settings)
+    // 화면 캡처 전용 스트리밍 시작 — 반드시 `startSettings`(로컬) 로 전달.
+    try await haishinKitManager.startScreenCaptureStreaming(with: startSettings)
     // 데이터 모니터링 시작 (네트워크 상태, FPS 등)
     startDataMonitoring()
     logInfo("✅ [화면캡처] 화면 캡처 스트리밍 서비스 시작 완료", category: .streaming)
+  }
+
+  /// 디바이스가 회전했을 때 호출되는 상시 동기화. 송출 중이 아닐 때만 settings 를 갱신한다.
+  @MainActor
+  func syncStreamOrientationFromDeviceIfIdle() {
+    switch status {
+    case .streaming, .connecting:
+      return
+    default:
+      break
+    }
+    guard let resolved = detectDeviceStreamOrientation() else { return }
+    guard settings.streamOrientation != resolved else { return }
+
+    NSLog(
+      "[USBCam] orientation observer: %@ → %@ (device=%@)",
+      settings.streamOrientation.rawValue,
+      resolved.rawValue,
+      describeCurrentDeviceOrientation()
+    )
+
+    updateSettings(
+      { $0.setStreamOrientation(resolved) },
+      updateStreamingAvailability: false
+    )
+  }
+
+  @MainActor
+  private func detectDeviceStreamOrientation() -> StreamOrientation? {
+    // 우선순위: foregroundActive scene.interfaceOrientation → 다른 scene → UIDevice.orientation
+    let scenes = UIApplication.shared.connectedScenes.compactMap { $0 as? UIWindowScene }
+    if let fg = scenes.first(where: { $0.activationState == .foregroundActive }),
+      fg.interfaceOrientation != .unknown
+    {
+      return streamOrientation(from: fg.interfaceOrientation)
+    }
+    if let any = scenes.first(where: { $0.interfaceOrientation != .unknown }) {
+      return streamOrientation(from: any.interfaceOrientation)
+    }
+    return streamOrientation(from: UIDevice.current.orientation)
+  }
+
+  private func streamOrientation(from interface: UIInterfaceOrientation) -> StreamOrientation? {
+    switch interface {
+    case .portrait, .portraitUpsideDown: return .portrait
+    case .landscapeLeft, .landscapeRight: return .landscape
+    default: return nil
+    }
+  }
+
+  private func streamOrientation(from device: UIDeviceOrientation) -> StreamOrientation? {
+    switch device {
+    case .portrait, .portraitUpsideDown: return .portrait
+    case .landscapeLeft, .landscapeRight: return .landscape
+    default: return nil
+    }
+  }
+
+  @MainActor
+  private func describeForegroundInterfaceOrientation() -> String {
+    let orientation = UIApplication.shared.connectedScenes
+      .compactMap { $0 as? UIWindowScene }
+      .first(where: { $0.activationState == .foregroundActive })?
+      .interfaceOrientation
+    return describe(orientation)
+  }
+
+  @MainActor
+  private func describeAnyInterfaceOrientation() -> String {
+    let orientation = UIApplication.shared.connectedScenes
+      .compactMap { $0 as? UIWindowScene }
+      .map { $0.interfaceOrientation }
+      .first(where: { $0 != .unknown })
+    return describe(orientation)
+  }
+
+  private func describeCurrentDeviceOrientation() -> String {
+    switch UIDevice.current.orientation {
+    case .portrait: return "portrait"
+    case .portraitUpsideDown: return "portraitUpsideDown"
+    case .landscapeLeft: return "landscapeLeft"
+    case .landscapeRight: return "landscapeRight"
+    case .faceUp: return "faceUp"
+    case .faceDown: return "faceDown"
+    case .unknown: return "unknown"
+    @unknown default: return "unknownFuture"
+    }
+  }
+
+  private func describe(_ interface: UIInterfaceOrientation?) -> String {
+    switch interface {
+    case .portrait: return "portrait"
+    case .portraitUpsideDown: return "portraitUpsideDown"
+    case .landscapeLeft: return "landscapeLeft"
+    case .landscapeRight: return "landscapeRight"
+    case .unknown: return "unknown"
+    case .none: return "nil"
+    @unknown default: return "unknownFuture"
+    }
   }
   /// 화면 캡처 스트리밍 시작 성공 후처리 (내부 메서드)
   /// **수행 작업:**

--- a/USBExternalCamera/ViewModels/LiveStreamViewModel+Setup.swift
+++ b/USBExternalCamera/ViewModels/LiveStreamViewModel+Setup.swift
@@ -118,6 +118,8 @@ extension LiveStreamViewModel {
 
     // 디바이스가 회전하면(그리고 송출 중이 아닐 때만) streamOrientation 을 즉시 동기화.
     // 다음에 라이브 시작을 눌렀을 때 stale 한 이전 세션의 방향이 남아 있지 않도록 보장.
+    // (초기 1회 동기화는 `loadInitialSettings` 완료 직후에 수행 — async 설정 로드가
+    //  뒤늦게 settings 를 덮어써서 우리 sync 가 무시되는 race 방지.)
     NotificationCenter.default
       .publisher(for: UIDevice.orientationDidChangeNotification)
       .receive(on: DispatchQueue.main)
@@ -125,11 +127,6 @@ extension LiveStreamViewModel {
         self?.syncStreamOrientationFromDeviceIfIdle()
       }
       .store(in: &cancellables)
-
-    // 앱 실행 직후에도 한 번은 동기화해두기 (회전 없이 바로 시작하는 경우 대비).
-    DispatchQueue.main.async { [weak self] in
-      self?.syncStreamOrientationFromDeviceIfIdle()
-    }
 
     logDebug("✅ [AUTO-SAVE] 설정 자동 저장 바인딩 완료", category: .streaming)
   }
@@ -159,6 +156,10 @@ extension LiveStreamViewModel {
         }
         self.updateStreamingAvailability()
         self.updateNetworkRecommendations()
+
+        // 설정 로드가 끝난 지금 시점에 안전하게 디바이스 방향과 동기화.
+        // (setupBindings 에서 바로 호출하면 이 블록에 의해 덮어써질 수 있음)
+        self.syncStreamOrientationFromDeviceIfIdle()
       }
     }
   }

--- a/USBExternalCamera/ViewModels/LiveStreamViewModel+Setup.swift
+++ b/USBExternalCamera/ViewModels/LiveStreamViewModel+Setup.swift
@@ -116,6 +116,21 @@ extension LiveStreamViewModel {
       logDebug("✅ [BINDING] HaishinKitManager와 바인딩 완료", category: .streaming)
     }
 
+    // 디바이스가 회전하면(그리고 송출 중이 아닐 때만) streamOrientation 을 즉시 동기화.
+    // 다음에 라이브 시작을 눌렀을 때 stale 한 이전 세션의 방향이 남아 있지 않도록 보장.
+    NotificationCenter.default
+      .publisher(for: UIDevice.orientationDidChangeNotification)
+      .receive(on: DispatchQueue.main)
+      .sink { [weak self] _ in
+        self?.syncStreamOrientationFromDeviceIfIdle()
+      }
+      .store(in: &cancellables)
+
+    // 앱 실행 직후에도 한 번은 동기화해두기 (회전 없이 바로 시작하는 경우 대비).
+    DispatchQueue.main.async { [weak self] in
+      self?.syncStreamOrientationFromDeviceIfIdle()
+    }
+
     logDebug("✅ [AUTO-SAVE] 설정 자동 저장 바인딩 완료", category: .streaming)
   }
   func loadInitialSettings() {

--- a/USBExternalCamera/Views/Camera/CameraPreviewUIView.swift
+++ b/USBExternalCamera/Views/Camera/CameraPreviewUIView.swift
@@ -192,6 +192,15 @@ final class CameraPreviewUIView: UIView {
       name: .stopScreenCapture,
       object: nil
     )
+
+    // 카메라 입력이 교체되면 새 AVCaptureConnection 이 기본 orientation 으로 만들어지므로
+    // 프리뷰 레이어의 회전/방향을 다시 적용해야 함 (세로 모드 회귀 방지).
+    NotificationCenter.default.addObserver(
+      self,
+      selector: #selector(handleCameraDidSwitch(_:)),
+      name: .cameraSessionDidSwitchCamera,
+      object: nil
+    )
   }
 
   @objc private func handleStartScreenCapture(_ notification: Notification) {
@@ -210,6 +219,19 @@ final class CameraPreviewUIView: UIView {
     logDebug("화면 캡처 중지 notification 수신", category: .streaming)
     clearStreamingTargetSize()
     stopScreenCapture()
+  }
+
+  @objc private func handleCameraDidSwitch(_ notification: Notification) {
+    logInfo("카메라 전환 notification 수신 - 프리뷰 연결 재적용", category: .camera)
+    DispatchQueue.main.async { [weak self] in
+      guard let self = self else { return }
+      // 새 AVCaptureDeviceInput 으로 갈아끼워지면 프리뷰 레이어 connection 은 기본 orientation 으로
+      // 재생성될 수 있다. 캐시 키를 무효화하고 현재 인터페이스 방향 기준으로 orientation 을 강제 재적용.
+      self.invalidatePreviewGeometryConfigCache()
+      self.invalidateVideoOutputConnectionConfigCache()
+      self.requestPreviewPresentationUpdate(forceConnectionRefresh: true)
+      self.refreshVideoOutputConnectionIfNeeded(force: true)
+    }
   }
 
   private func setupConstraints() {

--- a/USBExternalCamera/Views/Camera/CameraPreviewUIView.swift
+++ b/USBExternalCamera/Views/Camera/CameraPreviewUIView.swift
@@ -226,11 +226,12 @@ final class CameraPreviewUIView: UIView {
     DispatchQueue.main.async { [weak self] in
       guard let self = self else { return }
       // 새 AVCaptureDeviceInput 으로 갈아끼워지면 프리뷰 레이어 connection 은 기본 orientation 으로
-      // 재생성될 수 있다. 캐시 키를 무효화하고 현재 인터페이스 방향 기준으로 orientation 을 강제 재적용.
+      // 재생성될 수 있다. 캐시 키를 무효화한 뒤 강제 refresh 를 요청하면
+      // `performPreviewPresentationUpdate` 내부에서 프리뷰 connection 재적용과
+      // `refreshVideoOutputConnectionIfNeeded(force:)` 가 함께 수행된다.
       self.invalidatePreviewGeometryConfigCache()
       self.invalidateVideoOutputConnectionConfigCache()
       self.requestPreviewPresentationUpdate(forceConnectionRefresh: true)
-      self.refreshVideoOutputConnectionIfNeeded(force: true)
     }
   }
 


### PR DESCRIPTION
## Summary
HaishinKit 2.2.5 마이그레이션(#17) + 세로 송출 모드(#18) 이후 실기기 테스트에서 드러난 방향 회귀 두 건을 정리합니다.

### 1. 카메라 전환 시 송출 방향이 틀어지는 회귀 (\`3192ce9\`)
**재현**: 디바이스 세로 자세에서 라이브 중 카메라 변경 시 **프리뷰는 가로, 송출 영상은 24° 회전되어 가로 비율로 표시** (디바이스 가로에서는 문제 없음).

**원인**: \`switchToCamera\` 가 \`AVCaptureDeviceInput\` 을 교체하면 비디오 데이터 출력과 프리뷰 레이어 모두 기본 orientation 을 갖는 **새 AVCaptureConnection** 이 생성됩니다. 가로에서는 default 값이 우연히 맞아 증상이 없고, 세로에서는 회전이 필요하지만 재적용이 없어 깨집니다. \`switchDelegate.didSwitchCamera\` 는 선언만 있고 등록된 쪽이 없어 실효 없음.

**수정**:
- \`CameraSessionManager\` 가 마지막으로 적용한 rotation/orientation/mirror 을 캐시해 두고, \`switchToCamera\` 완료 직후 캐시 키를 무효화한 뒤 \`updateVideoOutputConfiguration\` 을 재호출 → 새 커넥션에도 동일 설정이 씌워짐.
- \`.cameraSessionDidSwitchCamera\` notification 을 새로 발송.
- \`CameraPreviewUIView\` 가 해당 notification 을 구독해 프리뷰 geometry/connection 캐시 무효화 + 강제 refresh → \`applyPreviewConnectionOrientation\` 이 새 프리뷰 connection 에 다시 적용됨.

### 2. 디바이스 회전 후 새 세션에서 이전 \`streamOrientation\` 이 그대로 쓰이는 회귀 (\`9d1f69a\`)
**재현**: 세로로 송출 → 종료 → 가로로 회전 → 재송출. 프리뷰는 가로로 맞게 적응하지만 **YouTube Studio 측에 전달되는 스트림은 9:16 프레임 안에 가로 영상이 레터박스**로 들어간 형태로 나감.

**원인**: \`LiveStreamSettingsModel.streamOrientation\` 은 \`UserDefaults\` 에 영속화되기 때문에 직전 세로 세션의 값이 남아 있음. 회전만 했을 뿐 이 값이 바뀌지 않으므로 \`startScreenCaptureStreaming(with: settings)\` 이 1080×1920 으로 publish.

**수정** (2중 장치):
- **상시 관찰자** (\`LiveStreamViewModel+Setup\`): \`UIDevice.orientationDidChangeNotification\` 을 Combine 으로 구독, 송출 중이 아닐 때만 \`settings.streamOrientation\` 을 즉시 갱신(\`setStreamOrientation\` 내부에서 \`normalizeVideoDimensionsForOrientation\` 도 수행). 설정 토글 UI 는 \`@Published\` 효과로 바로 동기화. 앱 시작 직후 1회도 동기화.
- **스트림 시작 safety net** (\`LiveStreamViewModel+ScreenCapture\`): 로컬 \`startSettings\` struct 를 만들어 방향 보정 후 그대로 매니저에 전달 → \`@Published\` 반영 타이밍과 독립. 감지 결과/입력 소스/해상도를 \`NSLog(\"[USBCam] …\")\` 로 남겨 Console.app 에서 privacy 필터 영향 없이 확인 가능.

검출 우선순위: foreground-active \`UIWindowScene.interfaceOrientation\` → 다른 scene → \`UIDevice.current.orientation\`.

## 검증
iPad Pro 12.9" 4세대 (iOS 26.4.1) 실기기에서:
- [x] 세로 자세 라이브 중 카메라 변경 → 프리뷰/송출 모두 세로 유지
- [x] 가로 자세 라이브 중 카메라 변경 → 회귀 없음
- [x] 세로 송출 종료 → 가로 회전 → 신규 송출 → 16:9 가로 송출이 YouTube Studio 로 전달됨
- [x] 가로 송출 종료 → 세로 회전 → 신규 송출 → 9:16 세로 송출이 YouTube Studio 로 전달됨

## Test plan
- [ ] 사용자가 의도적으로 설정 화면에서 반대 방향을 선택한 경우, 다음 회전이 관찰자에 의해 덮어쓰이는지 UX 회귀 여부 검토 (현재 정책: 디바이스 방향 우선)
- [ ] 외장 UVC 카메라 전환 경로에서도 연결 orientation 재적용이 동작하는지 현장 확인