### PR TITLE
refactor: derive PermissionViewModel state from PermissionManager

### DIFF
--- a/USBExternalCamera/ViewModels/MainViewModel.swift
+++ b/USBExternalCamera/ViewModels/MainViewModel.swift
@@ -298,10 +298,12 @@ final class MainViewModel: ObservableObject {
     /// 반응형 바인딩 설정
     /// ViewModel들 간의 상태 변화를 구독하여 UI 상태를 자동으로 업데이트합니다.
     private func setupBindings() {
-        // 권한 상태 변화 감지
-        permissionViewModel.$areAllPermissionsGranted
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] (areGranted: Bool) in
+        // 권한 상태 변화 감지. PermissionViewModel 이 PermissionManager 의 변경을 forward 하는
+        // publisher 를 노출하므로, willSet 시점의 stale value 를 피하기 위해 RunLoop.main 으로
+        // 한 tick 늦춰 didSet 이후의 값을 읽도록 한다.
+        permissionViewModel.permissionStatusChanges
+            .receive(on: RunLoop.main)
+            .sink { [weak self] in
                 self?.updateUIState()
             }
             .store(in: &cancellables)

--- a/USBExternalCamera/ViewModels/PermissionViewModel.swift
+++ b/USBExternalCamera/ViewModels/PermissionViewModel.swift
@@ -4,20 +4,15 @@ import AVFoundation
 import Combine
 
 /// 카메라/마이크 권한 상태를 SwiftUI 가 관찰할 수 있도록 노출하는 ViewModel.
-/// `PermissionManager` 의 시스템 권한 상태를 mirror 하면서 `areAllPermissionsGranted`
-/// 같은 파생 값을 계산하고, 권한 요청 / 시스템 설정 앱 라우팅 / foreground 자동 갱신을 담당합니다.
+/// 권한 자체는 `PermissionManager` 가 단일 source of truth — 이 ViewModel 은 그 값을
+/// computed 로 forward 하면서 권한 요청 / 시스템 설정 앱 라우팅 / foreground 자동 갱신과
+/// 같은 사용자 액션 측 책임만 추가합니다.
 @MainActor
 final class PermissionViewModel: ObservableObject {
 
     // MARK: - Dependencies
 
     let permissionManager: PermissionManager
-
-    // MARK: - Published Properties (UI State)
-
-    @Published var cameraStatus: PermissionStatus
-    @Published var microphoneStatus: PermissionStatus
-    @Published var areAllPermissionsGranted: Bool = false
 
     // MARK: - Private
 
@@ -27,61 +22,68 @@ final class PermissionViewModel: ObservableObject {
 
     init(permissionManager: PermissionManager) {
         self.permissionManager = permissionManager
-        self.cameraStatus = permissionManager.cameraStatus
-        self.microphoneStatus = permissionManager.microphoneStatus
 
-        updateAllPermissionsStatus()
+        // PermissionManager 의 published 변경을 본 ViewModel 의 objectWillChange 로 forward.
+        // SwiftUI 는 ObservableObject 의 objectWillChange 만 보므로, computed 프로퍼티 (cameraStatus
+        // 등) 를 읽는 뷰가 manager 변경에도 자동으로 재평가됩니다.
+        permissionManager.objectWillChange
+            .sink { [weak self] _ in
+                self?.objectWillChange.send()
+            }
+            .store(in: &cancellables)
 
         // 사용자가 시스템 설정 앱에서 권한을 변경하고 돌아오면 즉시 UI 에 반영.
         NotificationCenter.default
             .publisher(for: UIApplication.didBecomeActiveNotification)
             .sink { [weak self] _ in
                 Task { @MainActor [weak self] in
-                    self?.refreshStatus()
+                    self?.permissionManager.checkPermissions()
                 }
             }
             .store(in: &cancellables)
     }
 
+    // MARK: - Derived State (manager 가 single source of truth)
+
+    var cameraStatus: PermissionStatus { permissionManager.cameraStatus }
+    var microphoneStatus: PermissionStatus { permissionManager.microphoneStatus }
+    var areAllPermissionsGranted: Bool {
+        cameraStatus == .authorized && microphoneStatus == .authorized
+    }
+
+    /// 외부 (예: `MainViewModel`) 가 권한 상태 변화에만 반응하고 싶을 때 구독할 publisher.
+    /// `objectWillChange` 와 다르게 외부에 안정적인 인터페이스를 제공하고, `RunLoop.main` 으로
+    /// 한 tick 미뤄서 willSet 시점의 stale-value race 를 회피하는 구독측 코드를 단순화합니다.
+    var permissionStatusChanges: AnyPublisher<Void, Never> {
+        permissionManager.objectWillChange
+            .map { _ in () }
+            .eraseToAnyPublisher()
+    }
+
     // MARK: - Public Methods (User Actions)
 
-    /// 시스템 권한 상태를 다시 읽어들여 published 프로퍼티 + `areAllPermissionsGranted` 를 동기화합니다.
-    /// 카메라 세션이 켜지며 떴던 시스템 다이얼로그처럼, 앱이 명시적 `requestXxxPermission`
-    /// 을 거치지 않고 권한이 바뀐 경로에서도 UI 가 최신 상태를 반영하도록 합니다.
-    /// 변경 감지 가드를 적용해, foreground 마다 호출되어도 값이 같으면 publish 가 발생하지 않습니다.
     func refreshStatus() {
         permissionManager.checkPermissions()
-        if cameraStatus != permissionManager.cameraStatus {
-            cameraStatus = permissionManager.cameraStatus
-        }
-        if microphoneStatus != permissionManager.microphoneStatus {
-            microphoneStatus = permissionManager.microphoneStatus
-        }
-        updateAllPermissionsStatus()
     }
 
     /// 카메라 권한 요청.
     /// `.notDetermined` 만 시스템 다이얼로그를 띄울 수 있고, `.denied`/`.restricted` 는
     /// iOS 가 다이얼로그를 다시 띄우지 않으므로 시스템 설정 앱으로 사용자를 이동시킵니다.
     func requestCameraPermission() async {
-        if permissionManager.cameraStatus.requiresSystemSettings {
+        if cameraStatus.requiresSystemSettings {
             await openSystemSettings()
             return
         }
         await permissionManager.requestCameraPermission()
-        cameraStatus = permissionManager.cameraStatus
-        updateAllPermissionsStatus()
     }
 
     /// 마이크 권한 요청. 카메라와 동일한 분기 정책.
     func requestMicrophonePermission() async {
-        if permissionManager.microphoneStatus.requiresSystemSettings {
+        if microphoneStatus.requiresSystemSettings {
             await openSystemSettings()
             return
         }
         await permissionManager.requestMicrophonePermission()
-        microphoneStatus = permissionManager.microphoneStatus
-        updateAllPermissionsStatus()
     }
 
     private func openSystemSettings() async {
@@ -92,8 +94,8 @@ final class PermissionViewModel: ObservableObject {
     // MARK: - Derived Values
 
     /// 권한 안내 화면(`PermissionRequiredView`) 에 표시할 메시지.
-    /// `.notDetermined` 도 "허용 안 됨" 으로 잡습니다 — 사용자 입장에서는 아직 응답하지 않은
-    /// 상태나 거부한 상태나 모두 "허용되지 않은" 상태이기 때문입니다.
+    /// `.notDetermined` 도 "허용 안 됨" 으로 잡습니다 — 사용자 입장에서는 응답 전과 거부 모두
+    /// "허용되지 않은" 상태이기 때문입니다.
     var permissionGuideMessage: String {
         let pending = pendingPermissions
         if pending.isEmpty {
@@ -114,15 +116,5 @@ final class PermissionViewModel: ObservableObject {
             pending.append(NSLocalizedString("permission_microphone", comment: "마이크"))
         }
         return pending
-    }
-
-    // MARK: - Private Methods
-
-    /// 변경 감지 가드 — `areAllPermissionsGranted` 가 실제로 변할 때만 publish.
-    private func updateAllPermissionsStatus() {
-        let granted = cameraStatus == .authorized && microphoneStatus == .authorized
-        if areAllPermissionsGranted != granted {
-            areAllPermissionsGranted = granted
-        }
     }
 }


### PR DESCRIPTION
## Summary
PR #21 의 self-review 에서 보류했던 \`Quality #1\` 항목 — \`PermissionViewModel\` 의 @Published mirror 를 모두 computed 로 전환하여 single source of truth 로 \`PermissionManager\` 에 일원화.

## 변경
- \`PermissionViewModel\` 에서 다음 mirror 제거:
  - \`@Published var cameraStatus\`
  - \`@Published var microphoneStatus\`
  - \`@Published var areAllPermissionsGranted\`
- 위 세 프로퍼티는 모두 \`permissionManager\` 를 직접 forward 하는 computed 로 변경.
- \`updateAllPermissionsStatus()\` 메서드 제거 — 더 이상 mirror 가 없으므로 동기화 helper 불필요.
- \`refreshStatus()\` 는 \`permissionManager.checkPermissions()\` 만 호출하도록 단순화 — manager 가 자체적으로 published 변경을 발사.
- \`PermissionManager.objectWillChange\` 를 \`PermissionViewModel.objectWillChange\` 로 forward — SwiftUI 뷰가 ViewModel 만 관찰해도 manager 변경이 자동 반영.
- 외부 (\`MainViewModel\`) 가 권한 상태 변경을 구독할 때 사용하는 \`permissionStatusChanges: AnyPublisher<Void, Never>\` 노출.
- \`MainViewModel.setupBindings\` 의 \`$areAllPermissionsGranted\` 구독을 \`permissionStatusChanges\` + \`receive(on: RunLoop.main)\` 로 교체 (willSet 시점의 stale-value race 회피).

## 효과
- mirror plumbing ~35 lines 감소
- \`requestCameraPermission\` / \`requestMicrophonePermission\` 의 mirror copy-back 라인 제거
- single source of truth (PermissionManager) — 두 객체 사이 sync 가 깨질 가능성 제거
- foreground refresh / 권한 요청 / 시스템 설정 라우팅 동작은 그대로 유지

## 검증
- \`xcodebuild build -destination 'generic/platform=iOS' CODE_SIGNING_ALLOWED=NO\` ✅
- 변경 범위가 작고 (2 files / +39 -45) PR #21 의 권한 흐름 검증과 동일한 표면이라 디바이스 재검증은 수동 확인 권장 시나리오:
  - [ ] 콜드 런치 시 디테일뷰가 \`PermissionRequiredView\` 정상 표시
  - [ ] 시트의 카메라/마이크 row 가 권한 상태 변경에 즉시 반응
  - [ ] 권한 허용 후 자동으로 카메라 화면으로 전환
  - [ ] 시스템 설정에서 권한 토글 → 앱 복귀 시 자동 갱신